### PR TITLE
Enhance docs - comparisons, changelog, example usage in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![tests](https://github.com/datarootsio/databooks/actions/workflows/test.yml/badge.svg)](https://github.com/datarootsio/databooks/actions)
 
 
-`databooks` is a package for reducing the friction data scientists while using [Jupyter
-notebooks](https://jupyter.org/), by reducing the number of git conflicts between
-different notebooks and assisting in the resolution of the conflicts.
+`databooks` is a package to ease the collaboration between data scientists using
+[Jupyter notebooks](https://jupyter.org/), by reducing the number of git conflicts between
+different notebooks and resolution of git conflicts when encountered.
 
 The key features include:
 
@@ -33,7 +33,7 @@ The key features include:
 ## Installation
 
 ```
-pip install --i https://test.pypi.org/simple/ databooks
+pip install databooks
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # databooks
 [![maintained by dataroots](https://dataroots.io/maintained-rnd.svg)](https://dataroots.io)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![Codecov](https://codecov.io/github/datarootsio/databooks/main/graph/badge.svg)](https://github.com/datarootsio/databooks/actions)
 [![tests](https://github.com/datarootsio/databooks/actions/workflows/test.yml/badge.svg)](https://github.com/datarootsio/databooks/actions)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <img align="left" style="padding: 10px" width="120" height="120" src="https://raw.githubusercontent.com/datarootsio/databooks/main/docs/images/logo.png?token=AKUGIEI3HBAW32EUFUD5AT3BXT6BC">
 
 # databooks
-[![maintained by dataroots](https://dataroots.io/maintained.svg)](https://dataroots.io)
+[![maintained by dataroots](https://dataroots.io/maintained-rnd.svg)](https://dataroots.io)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Codecov](https://codecov.io/github/datarootsio/databooks/badge.svg?branch=main&service=github)](https://github.com/datarootsio/databooks/actions)
-[![tests](https://github.com/datarootsio/databooks/workflows/test/badge.svg?branch=main)](https://github.com/datarootsio/databooks/actions)
+[![Codecov](https://codecov.io/github/datarootsio/databooks/main/graph/badge.svg)](https://github.com/datarootsio/databooks/actions)
+[![tests](https://github.com/datarootsio/databooks/actions/workflows/test.yml/badge.svg)](https://github.com/datarootsio/databooks/actions)
 
 
 `databooks` is a package for reducing the friction data scientists while using [Jupyter
@@ -22,6 +22,7 @@ The key features include:
 ## Requirements
 
 `databooks` is built on top of:
+
 - Python 3.8+
 - [Typer](https://typer.tiangolo.com/)
 - [Rich](https://rich.readthedocs.io/en/latest/)

--- a/databooks/conflicts.py
+++ b/databooks/conflicts.py
@@ -30,7 +30,7 @@ def path2conflicts(
     """
     Get the difference model from the path based on the git conflict information.
 
-    :param nb_path: Path to file with conflicts (must be notebook paths)
+    :param nb_paths: Path to file with conflicts (must be notebook paths)
     :return: Generator of `DiffModel`s, to be resolved
     """
     if any(nb_path.suffix not in ("", ".ipynb") for nb_path in nb_paths):

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -1,0 +1,28 @@
+# Alternatives and comparisons
+There are many tools to improve the development experience with notebooks. `databooks`
+also takes inspiration from other existing packages.
+
+## `nb-clean`
+[`nb-clean`](https://github.com/srstevenson/nb-clean) provides a CLI tool to clear
+notebook metadata from Jupyter notebooks.
+
+**Differences:** `nb-clean` does not offer a way to resolve conflicts.
+
+## `nbdime`
+[`nbdime`](https://github.com/jupyter/nbdime) stands for "notebook diff and merge".
+It offers a way to compare and display the differences in the terminal. It offers a way
+to gracefully merge notebooks.
+
+**Differences:** `nb-dime` does not offer a way to remove metadata. `databooks` also
+fixes git merge conflicts instead of offering a way to do git merges ("ask for forgiveness
+not permission").
+
+## `nbdev`
+[`nbdev`](https://github.com/fastai/nbdev) offers a way to use notebooks to develop
+python packages, converting notebooks to python scripts and documentation. Also offers
+installation of pre-commit hooks to remove notebook metadata and a way to resolve git
+conflicts.
+
+**Differences:** `nbdev` is closer to an opinionated template for developing packages
+with notebooks. `databooks` is a configurable CLI tool for metadata removal and conflict
+resolution.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,71 @@
+---
+hide:
+  - navigation
+---
+
+# Usage
+
+`databooks` is a CLI tool, but there are many different ways in which one can make use
+of the tool - such as CI or hooks.
+
+## CLI tool
+
+The most straightforward way is to use it in the terminal, whenever desired. That can be
+error-prone and have "dirty" notebooks in your git repo. Check [CLI documentation](../CLI)
+for more information.
+
+A safer alternative is to automate this step, by setting up CI in your repo or a pre-commit hook.
+
+## GitHub Actions
+
+[GitHub Actions](https://github.com/features/actions) are a GitHub-hosted solution for
+CI/CD. All you need to get started is a file in `project_root/.github/workflows/nb-meta.yml`.
+
+An example workflow to clean any notebook metadata and commit changes at every push:
+
+```yml
+name: 'nb-meta'
+on: [push]
+
+jobs:
+  nb-meta:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Configure git user
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+      - name: Install dependencies and clean metadata
+        run: |
+          pip install databooks
+          databooks meta . --overwrite
+      - name: Commit changes and push
+        run: |
+          git commit -am "Automated commit - clean notebook metadata"
+          git push
+```
+
+Alternatively, one can choose to avoid having CI systems making code changes. In that
+case, we can only check whether notebooks have any undesired metadata.
+
+```yml
+name: 'nb-meta'
+on: [push]
+
+jobs:
+  nb-meta:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies and check metadata
+        run: |
+          pip install databooks
+          databooks meta . --check
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ extra_css:
 nav:
 - Home:
   - Overview: index.md
+  - Alternatives and comparisons: alternatives.md
   - License: license.md
 - CLI: CLI.md
 - API:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
 - Home:
   - Overview: index.md
   - Alternatives and comparisons: alternatives.md
+  - Changelog: https://github.com/datarootsio/databooks/releases
   - License: license.md
 - CLI: CLI.md
 - API:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
   - Alternatives and comparisons: alternatives.md
   - Changelog: https://github.com/datarootsio/databooks/releases
   - License: license.md
+- Usage: usage.md
 - CLI: CLI.md
 - API:
   - Overview: API.md


### PR DESCRIPTION
Enhance documentation with comparisons with other packages, linking github releases as changelog, simple CI usage (as suggested in #6) and minor fixes.