### PR TITLE
Bugfix/fix check exit status

### DIFF
--- a/databooks/cli.py
+++ b/databooks/cli.py
@@ -109,7 +109,7 @@ def meta(
                 f"Found unwanted metadata in {sum(not eq for eq in are_equal)} out of"
                 f" {len(are_equal)} files"
             )
-            Exit(code=1)
+            raise Exit(code=1)
     else:
         logger.info(
             f"The metadata of {sum(not eq for eq in are_equal)} out of {len(are_equal)}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,7 @@ def test_meta__check(tmpdir: LocalPath, caplog: LogCaptureFixture) -> None:
     nb_write = JupyterNotebook.parse_file(path=read_path)
 
     logs = list(caplog.records)
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert len(logs) == 1
     assert nb_read == nb_write
     assert logs[0].message == "Found unwanted metadata in 1 out of 1 files"


### PR DESCRIPTION
Currently, exit code when checking metadata is 0 regardless if unwanted metadata is found.
This PR fixes this behavior to returning 1 if any unwanted metadata is detected (code + tests).