### PR TITLE
Feature/enable removing cell fields for fixing conflicts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,10 @@ You can check the generation of documentation by running from the project root
 mkdocs serve
 ```
 
+### mike
+We also use the [`mike`](https://github.com/jimporter/mike) plugin in `MkDocs` to publish
+and keep different versions of documentation.
+
 ## Tests 🗳
 
 We use unit tests to ensure that our package works as expected. We use
@@ -112,6 +116,12 @@ root
 pytest --cov-report html --cov=databooks tests/
 ```
 
+## Publishing
+
+Publishing is automatically done via [Github Actions](https://github.com/features/actions)
+to PiPy. After published, a new tag and release are created. A new docs version is also
+published if all previous steps are successful.
+
 ## Contributors 👨‍💻👩‍💻
 
 `databooks` was created by [Murilo Cunha](https://github.com/murilo-cunha), and is
@@ -121,4 +131,5 @@ maintained by [dataroots](https://github.com/datarootsio).
 
 Special thanks to:
 
-[Bart](https://github.com/Bart6114) for feedback and support.
+[Bart](https://github.com/Bart6114) and [Nick](https://github.com/NickSchouten) for
+feedback and support.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img align="left" style="padding: 10px" width="120" height="120" src="https://raw.githubusercontent.com/datarootsio/databooks/main/docs/images/logo.png?token=AKUGIEI3HBAW32EUFUD5AT3BXT6BC">
+<img align="left" style="padding: 10px" width="120" height="120" src="https://raw.githubusercontent.com/datarootsio/databooks/main/docs/images/logo.png">
 
 # databooks
 [![maintained by dataroots](https://dataroots.io/maintained-rnd.svg)](https://dataroots.io)
@@ -6,6 +6,7 @@
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![Codecov](https://codecov.io/github/datarootsio/databooks/main/graph/badge.svg)](https://github.com/datarootsio/databooks/actions)
 [![tests](https://github.com/datarootsio/databooks/actions/workflows/test.yml/badge.svg)](https://github.com/datarootsio/databooks/actions)
+[![Downloads](https://pepy.tech/badge/databooks)](https://pepy.tech/project/databooks)
 
 
 `databooks` is a package to ease the collaboration between data scientists using
@@ -47,7 +48,7 @@ already avoid many of the conflicts.
 $ databooks meta [OPTIONS] PATHS...
 ```
 
-![databooks meta demo](https://raw.githubusercontent.com/datarootsio/databooks/main/docs/images/databooks-meta.gif?token=AKUGIEOHIY4XVJK2IRRMNRLBYJBEQ)
+![databooks meta demo](https://raw.githubusercontent.com/datarootsio/databooks/main/docs/images/databooks-meta.gif)
 
 ### Fix git conflicts for notebooks
 
@@ -58,7 +59,7 @@ the source notebooks that caused the conflicts and compares them (so no JSON man
 $ databooks fix [OPTIONS] PATHS...
 ```
 
-![databooks fix demo](https://raw.githubusercontent.com/datarootsio/databooks/main/docs/images/databooks-fix.gif?token=AKUGIELRRMXJMU7RSUUGYUDBYJD5G)
+![databooks fix demo](https://raw.githubusercontent.com/datarootsio/databooks/main/docs/images/databooks-fix.gif)
 
 ## License
 

--- a/databooks/cli.py
+++ b/databooks/cli.py
@@ -138,6 +138,13 @@ def fix(
         help="Whether to keep the cells from the first or last notebook."
         " Omit to keep both",
     ),
+    cell_fields_ignore: List[str] = Option(
+        [
+            "id",
+            "execution_count",
+        ],
+        help="Cell fields to remove before comparing cells",
+    ),
     interactive: bool = Option(
         False,
         "--interactive",
@@ -176,6 +183,7 @@ def fix(
             conflict_files=conflict_files,
             keep_first=metadata_first,
             cells_first=cells_first,
+            cell_fields_ignore=cell_fields_ignore,
             verbose=verbose,
             progress_callback=lambda: progress.update(conflicts, advance=1),
         )

--- a/databooks/cli.py
+++ b/databooks/cli.py
@@ -1,6 +1,7 @@
 """Main CLI application."""
 from importlib.metadata import metadata
 from pathlib import Path
+from textwrap import dedent
 from typing import List, Optional
 
 from rich.progress import (
@@ -17,7 +18,7 @@ from databooks.conflicts import conflicts2nbs, path2conflicts
 from databooks.logging import get_logger
 from databooks.metadata import clear_all
 
-_DISTRIBUTION_METADATA = metadata("databooks")
+_DISTRIBUTION_METADATA = metadata(__package__)
 
 logger = get_logger(__file__)
 
@@ -41,7 +42,7 @@ def callback(  # noqa: D103
 
 
 # add docs dynamically from `pyproject.toml`
-callback.__doc__ = _DISTRIBUTION_METADATA["Summary"]
+callback.__doc__ = dedent(_DISTRIBUTION_METADATA["Summary"])
 
 
 @app.command()

--- a/databooks/cli.py
+++ b/databooks/cli.py
@@ -2,7 +2,6 @@
 from importlib.metadata import metadata
 from itertools import compress
 from pathlib import Path
-from textwrap import dedent
 from typing import List, Optional
 
 from rich.progress import (
@@ -43,7 +42,7 @@ def callback(  # noqa: D103
 
 
 # add docs dynamically from `pyproject.toml`
-callback.__doc__ = dedent(_DISTRIBUTION_METADATA["Summary"])
+callback.__doc__ = _DISTRIBUTION_METADATA["Summary"]
 
 
 @app.command()

--- a/databooks/cli.py
+++ b/databooks/cli.py
@@ -129,13 +129,12 @@ def meta(
 def fix(
     paths: List[Path] = Argument(..., help="Path(s) of notebook files with conflicts"),
     ignore: List[str] = Option(["!*"], help="Glob expression(s) of files to ignore"),
-    metadata_first: bool = Option(
-        True, help="Whether or not to keep the metadata from the first/current notebook"
+    metadata_head: bool = Option(
+        True, help="Whether or not to keep the metadata from the head/current notebook"
     ),
-    cells_first: Optional[bool] = Option(
+    cells_head: Optional[bool] = Option(
         None,
-        help="Whether to keep the cells from the first or last notebook."
-        " Omit to keep both",
+        help="Whether to keep the cells from the head/base notebook. Omit to keep both",
     ),
     cell_fields_ignore: List[str] = Option(
         [
@@ -180,8 +179,8 @@ def fix(
         )
         conflicts2nbs(
             conflict_files=conflict_files,
-            keep_first=metadata_first,
-            cells_first=cells_first,
+            meta_first=metadata_head,
+            cells_first=cells_head,
             cell_fields_ignore=cell_fields_ignore,
             verbose=verbose,
             progress_callback=lambda: progress.update(conflicts, advance=1),

--- a/databooks/cli.py
+++ b/databooks/cli.py
@@ -12,8 +12,9 @@ from rich.progress import (
 )
 from typer import Argument, BadParameter, Exit, Option, Typer, echo
 
-from databooks.common import expand_paths, get_logger
+from databooks.common import expand_paths
 from databooks.conflicts import conflicts2nbs, path2conflicts
+from databooks.logging import get_logger
 from databooks.metadata import clear_all
 
 _DISTRIBUTION_METADATA = metadata("databooks")

--- a/databooks/common.py
+++ b/databooks/common.py
@@ -1,36 +1,10 @@
 """Common set of miscellaneous functions."""
 import json
-import logging
-import os
 from itertools import chain
 from pathlib import Path
 from typing import List
 
-from rich.logging import RichHandler
-
 from databooks import JupyterNotebook
-
-
-def get_logger(name: str) -> logging.Logger:
-    """Get logger with rich configuration."""
-    level = os.getenv("LOG_LEVEL", logging.INFO)
-
-    logging.basicConfig(
-        level=level,
-        format="%(message)s",
-        datefmt="[%X]",
-        handlers=[RichHandler(rich_tracebacks=True)],
-    )
-    return logging.getLogger(name)
-
-
-def set_verbose(logger: logging.Logger) -> None:
-    """Set logger to DEBUG level when user requests verbosity."""
-    verbose_level = logging.DEBUG
-    logger.setLevel(verbose_level)
-    logger.debug(
-        f"Verbose mode: setting log level to {logging.getLevelName(verbose_level)}"
-    )
 
 
 def write_notebook(nb: JupyterNotebook, path: Path) -> None:

--- a/databooks/conflicts.py
+++ b/databooks/conflicts.py
@@ -7,10 +7,11 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 from git import Repo
 
-from databooks.common import get_logger, set_verbose, write_notebook
+from databooks.common import write_notebook
 from databooks.data_models.base import BaseCells, DiffModel
 from databooks.data_models.notebook import Cell, Cells, JupyterNotebook
 from databooks.git_utils import ConflictFile, get_conflict_blobs, get_repo
+from databooks.logging import get_logger, set_verbose
 
 logger = get_logger(__file__)
 

--- a/databooks/conflicts.py
+++ b/databooks/conflicts.py
@@ -32,6 +32,7 @@ def path2conflicts(
     Get the difference model from the path based on the git conflict information.
 
     :param nb_paths: Path to file with conflicts (must be notebook paths)
+    :param repo: The git repo to look for conflicts
     :return: Generator of `DiffModel`s, to be resolved
     """
     if any(nb_path.suffix not in ("", ".ipynb") for nb_path in nb_paths):

--- a/databooks/conflicts.py
+++ b/databooks/conflicts.py
@@ -51,7 +51,7 @@ def path2conflicts(
 def conflict2nb(
     conflict_file: ConflictFile,
     *,
-    keep_first: bool = True,
+    meta_first: bool = True,
     cells_first: Optional[bool] = None,
     cell_fields_ignore: Sequence[str] = ("id", "execution_count"),
     ignore_none: bool = True,
@@ -61,7 +61,7 @@ def conflict2nb(
     Merge diffs from conflicts and return valid a notebook.
 
     :param conflict_file: A `databooks.git_utils.ConflictFile` with conflicts
-    :param keep_first: Whether to keep the metadata of the first or last notebook
+    :param meta_first: Whether to keep the metadata of the first or last notebook
     :param cells_first: Whether to keep the cells of the first or last notebook
     :param ignore_none: Keep all metadata fields even if it's included in only one
      notebook
@@ -80,7 +80,7 @@ def conflict2nb(
         msg = (
             f"Notebook metadata conflict for {conflict_file.filename}. Keeping "
             + "first."
-            if keep_first
+            if meta_first
             else "last."
         )
         logger.debug(msg)
@@ -97,7 +97,7 @@ def conflict2nb(
         JupyterNotebook,
         diff_nb.resolve(
             ignore_none=ignore_none,
-            keep_first=keep_first,
+            keep_first=meta_first,
             keep_first_cells=cells_first,
             first_id=conflict_file.first_log,
             last_id=conflict_file.last_log,

--- a/databooks/data_models/notebook.py
+++ b/databooks/data_models/notebook.py
@@ -60,9 +60,11 @@ class Cell(DatabooksBase):
 
     def remove_fields(self, *args: Any, **kwargs: Any) -> None:
         """
-        Overwrite databooks.data_models.DatabooksBase.remove_fields to raise warning
-         in favour of `Cell.clear_metadata` instead, as it preserve the Jupyter notebook
-         schema.
+        Remove Cell fields with a warning.
+
+        Overwrite `databooks.data_models.DatabooksBase.remove_fields` to raise warning
+         in favour of `Cell.clear_metadata` instead, as it preserves a valid Jupyter
+         Notebook schema.
         """
         logger.warning(
             "Removing fields in `databooks.data_models.notebook.Cell` may yield invalid"

--- a/databooks/data_models/notebook.py
+++ b/databooks/data_models/notebook.py
@@ -182,32 +182,26 @@ class Cells(GenericModel, BaseCells[T]):
                 f" `{type(other).__name__}`"
             )
 
-        _self = deepcopy(self)
-        _other = deepcopy(other)
-        for cells in (_self, _other):
-            for cell in cells:
-                cell.remove_fields(["id"], missing_ok=True)
-
         # By setting the context to the max number of cells and using
         #  `pathlib.SequenceMatcher.get_grouped_opcodes` we essentially get the same
         #  result as `pathlib.SequenceMatcher.get_opcodes` but in smaller chunks
-        n_context = max(len(_self), len(_other))
+        n_context = max(len(self), len(other))
         diff_opcodes = list(
             SequenceMatcher(
-                isjunk=None, a=_self, b=_other, autojunk=False
+                isjunk=None, a=self, b=other, autojunk=False
             ).get_grouped_opcodes(n_context)
         )
 
         if len(diff_opcodes) > 1:
             raise RuntimeError(
                 "Expected one group for opcodes when context size is "
-                f" {n_context} for {len(_self)} and {len(_other)} cells in"
+                f" {n_context} for {len(self)} and {len(other)} cells in"
                 " notebooks."
             )
         return Cells[Tuple[List[Cell], List[Cell]]](
             [
                 # https://github.com/python/mypy/issues/9459
-                tuple((_self.data[i1:j1], _other.data[i2:j2]))  # type: ignore
+                tuple((self.data[i1:j1], other.data[i2:j2]))  # type: ignore
                 for _, i1, j1, i2, j2 in chain.from_iterable(diff_opcodes)
             ]
         )

--- a/databooks/data_models/notebook.py
+++ b/databooks/data_models/notebook.py
@@ -102,7 +102,7 @@ class Cell(DatabooksBase):
 
         cell_fields = self.__fields__  # especified in Class definition
         if any(field in cell_remove_fields for field in cell_fields):
-            logger.warning(
+            logger.debug(
                 "Ignoring removal of "
                 + str([f for f in cell_remove_fields if f in cell_fields])
                 + f" - removing fields yields invalid `{type(self).__name__}`."

--- a/databooks/data_models/notebook.py
+++ b/databooks/data_models/notebook.py
@@ -72,9 +72,9 @@ class Cell(DatabooksBase):
         cell_fields = self.__fields__  # required fields especified in class definition
         if any(field in fields for field in cell_fields):
             logger.debug(
-                "Ignoring removal of "
+                "Ignoring removal of required fields "
                 + str([f for f in fields if f in cell_fields])
-                + f" - removing fields yields invalid `{type(self).__name__}`."
+                + f" in `{type(self).__name__}`."
             )
             fields = [f for f in fields if f not in cell_fields]
 

--- a/databooks/data_models/notebook.py
+++ b/databooks/data_models/notebook.py
@@ -112,12 +112,13 @@ class Cell(DatabooksBase):
             cell_remove_fields = [f for f in cell_remove_fields if f not in cell_fields]
 
         super(Cell, self).remove_fields(cell_remove_fields, missing_ok=True)
+
         if self.cell_type == "code":
             self.outputs: List[Dict[str, Any]] = (
-                [] if "outputs" not in cell_fields else self.outputs
+                [] if "outputs" not in dict(self) else self.outputs
             )
             self.execution_count: Optional[PositiveInt] = (
-                None if "execution_count" not in cell_fields else self.execution_count
+                None if "execution_count" not in dict(self) else self.execution_count
             )
 
     @validator("cell_type")

--- a/databooks/data_models/notebook.py
+++ b/databooks/data_models/notebook.py
@@ -22,6 +22,9 @@ from pydantic import Extra, root_validator, validator
 from pydantic.generics import GenericModel
 
 from databooks.data_models.base import BaseCells, DatabooksBase
+from databooks.logging import get_logger
+
+logger = get_logger(__file__)
 
 
 class NotebookMetadata(DatabooksBase):

--- a/databooks/git_utils.py
+++ b/databooks/git_utils.py
@@ -5,7 +5,7 @@ from typing import Dict, List, cast
 
 from git import Blob, Git, Repo  # type: ignore
 
-from databooks.common import get_logger
+from databooks.logging import get_logger
 
 logger = get_logger(name=__file__)
 

--- a/databooks/logging.py
+++ b/databooks/logging.py
@@ -1,0 +1,25 @@
+"""Logging helper functions."""
+
+import logging
+
+from rich.logging import RichHandler
+
+
+def get_logger(name: str, level: str = "INFO") -> logging.Logger:
+    """Get logger with rich configuration."""
+    logging.basicConfig(
+        level=level,
+        format="%(message)s",
+        datefmt="[%X]",
+        handlers=[RichHandler(rich_tracebacks=True)],
+    )
+    return logging.getLogger(name)
+
+
+def set_verbose(logger: logging.Logger) -> None:
+    """Set logger to DEBUG level when user requests verbosity."""
+    verbose_level = logging.DEBUG
+    logger.setLevel(verbose_level)
+    logger.debug(
+        f"Verbose mode: setting log level to {logging.getLevelName(verbose_level)}"
+    )

--- a/databooks/metadata.py
+++ b/databooks/metadata.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from typing import Any, Callable, List, Optional, Sequence
 
 from databooks import JupyterNotebook
-from databooks.common import get_logger, set_verbose, write_notebook
+from databooks.common import write_notebook
+from databooks.logging import get_logger, set_verbose
 
 logger = get_logger(__file__)
 

--- a/databooks/metadata.py
+++ b/databooks/metadata.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, List, Optional, Sequence
 
 from databooks import JupyterNotebook
 from databooks.common import write_notebook
+from databooks.data_models.notebook import Cell
 from databooks.logging import get_logger, set_verbose
 
 logger = get_logger(__file__)
@@ -14,6 +15,7 @@ def clear(
     write_path: Optional[Path] = None,
     notebook_metadata_keep: Sequence[str] = (),
     cell_metadata_keep: Sequence[str] = (),
+    cell_keep_fields: List[str] = [],
     check: bool = False,
     verbose: bool = False,
     **kwargs: Any,
@@ -27,6 +29,7 @@ def clear(
     :param write_path: Path of notebook file with metadata to be cleaned
     :param notebook_metadata_keep: Notebook metadata fields to keep
     :param cell_metadata_keep: Cell metadata fields to keep
+    :param cell_keep_fields: Cell fields to keep
     :param check: Don't write any files, check whether there is unwanted metadata
     :param verbose: Log written files
     :param kwargs: Additional keyword arguments to pass to
@@ -40,9 +43,18 @@ def clear(
         write_path = read_path
     notebook = JupyterNotebook.parse_file(read_path)
 
+    # Get fields to remove from cells
+    cell_fields = {field for cell in notebook.cells for field, _ in cell if field}
+    cell_keep_fields += list(Cell.__fields__)  # required field for notebook schema
+
+    cell_remove_fields = [
+        field for field in cell_fields if field not in cell_keep_fields
+    ]
+
     notebook.clear_metadata(
         notebook_metadata_keep=notebook_metadata_keep,
         cell_metadata_keep=cell_metadata_keep,
+        cell_remove_fields=cell_remove_fields,
         **kwargs,
     )
     nb_equals = notebook == JupyterNotebook.parse_file(read_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,13 +111,13 @@ def test_fix(tmpdir: LocalPath) -> None:
     id_other = conflict_files[0].last_log
 
     # Run CLI and check conflict resolution
-    result = runner.invoke(app, ["fix", str(tmpdir)])
+    result = runner.invoke(app, ["fix", str(tmpdir), "--cell-fields-ignore", "id"])
     fixed_notebook = JupyterNotebook.parse_file(path=tmpdir / nb_path)
 
     assert len(conflict_files) == 1
     assert result.exit_code == 0
 
-    # add `tags` since we use `databooks.data_models.base.resolve` with default
+    # Add `tags` since we use `databooks.data_models.base.resolve` with default
     #  `ignore_none = True`
     assert fixed_notebook.metadata == NotebookMetadata(
         **notebook_1.metadata.dict(), **{"tags": []}

--- a/tests/test_data_models/test_notebook.py
+++ b/tests/test_data_models/test_notebook.py
@@ -136,15 +136,15 @@ class TestCell:
         logs = list(caplog.records)
 
         assert cell.dict() == dict(
+            cell_type="code",
             metadata=self.cell_metadata,
             source=["test_source"],
             execution_count=1,
+            outputs=[],
         )
         assert len(logs) == 1
         assert logs[0].message == (
-            "Removing fields in `databooks.data_models.notebook.Cell` may yield invalid"
-            " notebook. Use `databooks.data_models.notebook.Cell.clear_metadata` with a"
-            " `cell_remove_fields` parameter instead."
+             "Ignoring removal of ['cell_type'] - removing fields yields invalid `Cell`."
         )
 
 

--- a/tests/test_data_models/test_notebook.py
+++ b/tests/test_data_models/test_notebook.py
@@ -128,6 +128,25 @@ class TestCell:
             [([self.cell], [self.cell]), ([], [self.cell])]  # type: ignore
         )
 
+    def test_cell_remove_fields(self, caplog: LogCaptureFixture) -> None:
+        """Test remove fields with logs"""
+        caplog.set_level(logging.DEBUG)
+        cell = deepcopy(self.cell)
+        cell.remove_fields(["cell_type", "outputs"])  # yields invalid `cell`
+        logs = list(caplog.records)
+
+        assert cell.dict() == dict(
+            metadata=self.cell_metadata,
+            source=["test_source"],
+            execution_count=1,
+        )
+        assert len(logs) == 1
+        assert logs[0].message == (
+            "Removing fields in `databooks.data_models.notebook.Cell` may yield invalid"
+            " notebook. Use `databooks.data_models.notebook.Cell.clear_metadata` with a"
+            " `cell_remove_fields` parameter instead."
+        )
+
 
 class TestJupyterNotebook(TestNotebookMetadata, TestCell):
     """Tests related to notebooks."""

--- a/tests/test_data_models/test_notebook.py
+++ b/tests/test_data_models/test_notebook.py
@@ -112,7 +112,7 @@ class TestCell:
         )
         assert len(logs) == 1
         assert logs[0].message == (
-            "Ignoring removal of ['source'] - removing fields yields invalid `Cell`."
+            "Ignoring removal of required fields ['source'] in `Cell`."
         )
 
     def test_cells_sub(self) -> None:
@@ -144,7 +144,7 @@ class TestCell:
         )
         assert len(logs) == 1
         assert logs[0].message == (
-             "Ignoring removal of ['cell_type'] - removing fields yields invalid `Cell`."
+            "Ignoring removal of required fields ['cell_type'] in `Cell`."
         )
 
 

--- a/tests/test_data_models/test_notebook.py
+++ b/tests/test_data_models/test_notebook.py
@@ -165,7 +165,9 @@ class TestJupyterNotebook(TestNotebookMetadata, TestCell):
         """Remove metadata specified in JupyterNotebook - cells and notebook levels."""
         notebook = self.jupyter_notebook
         notebook.clear_metadata(
-            notebook_metadata_keep=[], cell_metadata_keep=[], cell_outputs=True
+            notebook_metadata_keep=[],
+            cell_metadata_keep=[],
+            cell_remove_fields=["outputs", "execution_count"],
         )
 
         assert all(cell.metadata == CellMetadata() for cell in notebook.cells)

--- a/tests/test_data_models/test_notebook.py
+++ b/tests/test_data_models/test_notebook.py
@@ -129,7 +129,7 @@ class TestCell:
         )
 
     def test_cell_remove_fields(self, caplog: LogCaptureFixture) -> None:
-        """Test remove fields with logs"""
+        """Test remove fields with logs."""
         caplog.set_level(logging.DEBUG)
         cell = deepcopy(self.cell)
         cell.remove_fields(["cell_type", "outputs"])  # yields invalid `cell`

--- a/tests/test_data_models/test_notebook.py
+++ b/tests/test_data_models/test_notebook.py
@@ -115,7 +115,7 @@ class TestCell:
             "Ignoring removal of ['source'] - removing fields yields invalid `Cell`."
         )
 
-    def test_sub_cells(self) -> None:
+    def test_cells_sub(self) -> None:
         """Get the diff from different `Cells`."""
         dl1 = Cells[Cell]([self.cell])
         dl2 = Cells[Cell]([self.cell] * 2)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -22,7 +22,7 @@ def test_metadata_clear__check_verbose(
     clear(
         read_path=read_path,
         write_path=write_path,
-        cell_outputs=True,
+        cell_keep_fields=["outputs"],
         check=True,
         verbose=True,
     )
@@ -49,7 +49,7 @@ def test_metadata_clear(tmpdir: LocalPath) -> None:
     clear(
         read_path=read_path,
         write_path=write_path,
-        cell_outputs=True,
+        cell_keep_fields=["cell_type", "source", "metadata"],
     )
 
     nb_read = JupyterNotebook.parse_file(path=read_path)


### PR DESCRIPTION
feature: enable removing cell fields before fixing conflicts

Depending on the Jupyter version, there may be additional fields, such as a unique `id`. If it is present, then that would make all the cells different regardless of the content. Additionally, the user may want to disregard outputs, execution counts or metadata when fixing a notebook with conflicts (if this information is relevant, then keep both select desired cell(s)).

Add a `cell_fields_ignore` parameter in the `databooks fix` command of the CLI that specifies which fields to be removed from cells before fixing conflicts. In doing so, removing `execution_count` or `outputs` also becomes a use for removing cell fields (and not a special case).

Minor changes:
- CI
- CLI parameters renaming