### PR TITLE
Rename vars to disambiguate between`metadata` and `fields`

### DIFF
--- a/databooks/cli.py
+++ b/databooks/cli.py
@@ -87,7 +87,7 @@ def meta(
             logger.warning(f"{len(nb_paths)} files will be overwritten")
 
     write_paths = [p.parent / (prefix + p.stem + suffix + p.suffix) for p in nb_paths]
-    cell_keep_fields = list(
+    cell_fields_keep = list(
         compress(["outputs", "execution_count"], (not v for v in (rm_outs, rm_exec)))
     ) + list(cell_fields_keep)
     with Progress(
@@ -105,7 +105,7 @@ def meta(
             progress_callback=lambda: progress.update(metadata, advance=1),
             notebook_metadata_keep=nb_meta_keep,
             cell_metadata_keep=cell_meta_keep,
-            cell_keep_fields=cell_keep_fields,
+            cell_fields_keep=cell_fields_keep,
             check=check,
             verbose=verbose,
         )

--- a/databooks/data_models/notebook.py
+++ b/databooks/data_models/notebook.py
@@ -65,8 +65,8 @@ class Cell(DatabooksBase):
         """
         Remove Cell fields.
 
-        Similar to `databooks.data_models.base.remove_fields`, but include required
-         fields for Jupyter notebook cells.
+        Similar to `databooks.data_models.base.remove_fields`, but will ignore required
+         fields for `databooks.data_models.notebook.Cell`.
         """
         # Ignore required `Cell` fields
         cell_fields = self.__fields__  # required fields especified in class definition
@@ -88,7 +88,7 @@ class Cell(DatabooksBase):
                 None if "execution_count" not in dict(self) else self.execution_count
             )
 
-    def clear_metadata(
+    def clear_fields(
         self,
         *,
         cell_metadata_keep: Sequence[str] = None,
@@ -96,8 +96,10 @@ class Cell(DatabooksBase):
         cell_remove_fields: Sequence[str] = (),
     ) -> None:
         """
-        Clear cell metadata, execution count and outputs.
+        Clear cell metadata, execution count, outputs or other desired fields (id, ...).
 
+        You can also specify metadata to keep or remove from the `metadata` property of
+         `databooks.data_models.notebook.Cell`.
         :param cell_metadata_keep: Metadata values to keep - simply pass an empty
          sequence (i.e.: `()`) to remove all extra fields.
         :param cell_metadata_remove: Metadata values to remove
@@ -349,5 +351,5 @@ class JupyterNotebook(DatabooksBase, extra=Extra.forbid):
         if len(cell_kwargs) > 0:
             _clean_cells = deepcopy(self.cells)
             for cell in _clean_cells:
-                cell.clear_metadata(**cell_kwargs)
+                cell.clear_fields(**cell_kwargs)
             self.cells = _clean_cells

--- a/databooks/metadata.py
+++ b/databooks/metadata.py
@@ -15,7 +15,7 @@ def clear(
     write_path: Optional[Path] = None,
     notebook_metadata_keep: Sequence[str] = (),
     cell_metadata_keep: Sequence[str] = (),
-    cell_keep_fields: List[str] = [],
+    cell_fields_keep: List[str] = [],
     check: bool = False,
     verbose: bool = False,
     **kwargs: Any,
@@ -29,7 +29,7 @@ def clear(
     :param write_path: Path of notebook file with metadata to be cleaned
     :param notebook_metadata_keep: Notebook metadata fields to keep
     :param cell_metadata_keep: Cell metadata fields to keep
-    :param cell_keep_fields: Cell fields to keep
+    :param cell_fields_keep: Cell fields to keep
     :param check: Don't write any files, check whether there is unwanted metadata
     :param verbose: Log written files
     :param kwargs: Additional keyword arguments to pass to
@@ -45,10 +45,10 @@ def clear(
 
     # Get fields to remove from cells
     cell_fields = {field for cell in notebook.cells for field, _ in cell if field}
-    cell_keep_fields += list(Cell.__fields__)  # required field for notebook schema
+    cell_fields_keep += list(Cell.__fields__)  # required field for notebook schema
 
     cell_remove_fields = [
-        field for field in cell_fields if field not in cell_keep_fields
+        field for field in cell_fields if field not in cell_fields_keep
     ]
 
     notebook.clear_metadata(

--- a/tests/test_data_models/test_notebook.py
+++ b/tests/test_data_models/test_notebook.py
@@ -96,7 +96,7 @@ class TestCell:
 
         assert cell.metadata is not None
 
-        cell.clear_metadata(
+        cell.clear_fields(
             cell_metadata_keep=[],
             cell_remove_fields=["execution_count", "outputs", "source"],
         )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -22,7 +22,7 @@ def test_metadata_clear__check_verbose(
     clear(
         read_path=read_path,
         write_path=write_path,
-        cell_keep_fields=["outputs"],
+        cell_fields_keep=["outputs"],
         check=True,
         verbose=True,
     )
@@ -49,7 +49,7 @@ def test_metadata_clear(tmpdir: LocalPath) -> None:
     clear(
         read_path=read_path,
         write_path=write_path,
-        cell_keep_fields=["cell_type", "source", "metadata"],
+        cell_fields_keep=["cell_type", "source", "metadata"],
     )
 
     nb_read = JupyterNotebook.parse_file(path=read_path)


### PR DESCRIPTION
Disambiguate between `metadata` and `fields` by renaming methods and arguments.

`databooks.data_models.notebook.Cell` has a `metadata` field which is not to be confused with metadata fields such as `execution_count` or `outputs`.