### PR TITLE
remove unnecessary `require_serial` from pre-commit config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,5 +5,4 @@
   entry: databooks meta
   language: python
   minimum_pre_commit_version: 2.9.2
-  require_serial: true
   types: [jupyter]


### PR DESCRIPTION
As suggested in [pre-commit's PR](https://github.com/pre-commit/pre-commit.com/pull/615)