### PR TITLE
fix clearing cell fields before comparing

### DIFF
--- a/databooks/conflicts.py
+++ b/databooks/conflicts.py
@@ -75,6 +75,13 @@ def conflict2nb(
         )
         logger.debug(msg)
 
+    if cell_fields_ignore:
+        for cells in (nb_1.cells, nb_2.cells):
+            for cell in cells:
+                cell.clear_fields(
+                    cell_metadata_remove=[], cell_remove_fields=cell_fields_ignore
+                )
+
     diff_nb = nb_1 - nb_2
     nb = diff_nb.resolve(
         ignore_none=ignore_none,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -209,6 +209,11 @@ def test_fix(tmpdir: LocalPath) -> None:
 
     expected_metadata = deepcopy(notebook_2.metadata.dict())
     expected_metadata.update(notebook_1.metadata.dict())
+    notebook_1.clear_metadata(
+        notebook_metadata_remove=(),
+        cell_metadata_remove=(),
+        cell_remove_fields=["execution_count"],
+    )
     assert fixed_notebook.metadata == NotebookMetadata(**expected_metadata)
     assert fixed_notebook.nbformat == notebook_1.nbformat
     assert fixed_notebook.nbformat_minor == notebook_1.nbformat_minor
@@ -281,6 +286,11 @@ def test_fix__config(tmpdir: LocalPath) -> None:
 
     expected_metadata = deepcopy(notebook_1.metadata.dict())
     expected_metadata.update(notebook_2.metadata.dict())
+    notebook_1.clear_metadata(
+        notebook_metadata_remove=(),
+        cell_metadata_remove=(),
+        cell_remove_fields=["execution_count"],
+    )
     assert fixed_notebook.metadata == NotebookMetadata(**expected_metadata)
     assert fixed_notebook.nbformat == notebook_2.nbformat
     assert fixed_notebook.nbformat_minor == notebook_2.nbformat_minor


### PR DESCRIPTION
needed to remove metadata such as `id` that would make every cell be different