### PR TITLE
Allow type annotations on imports (PEP-561)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -187,11 +187,11 @@ python-versions = "*"
 
 [[package]]
 name = "jinja2"
-version = "3.1.1"
+version = "3.0.3"
 description = "A very fast and expressive template engine."
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
 MarkupSafe = ">=2.0"
@@ -663,7 +663,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "da7fe5a2a4b5998805b0a6b5d54254a7a56ac83efbc45b6d526a86cb79c403cb"
+content-hash = "98a073e58abcdeadf803ee60f70118b4b26d0aa93214eea8783ebe6d6cc3638a"
 
 [metadata.files]
 astunparse = [
@@ -774,8 +774,8 @@ iniconfig = [
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 jinja2 = [
-    {file = "Jinja2-3.1.1-py3-none-any.whl", hash = "sha256:539835f51a74a69f41b848a9645dbdc35b4f20a3b601e2d9a7e22947b15ff119"},
-    {file = "Jinja2-3.1.1.tar.gz", hash = "sha256:640bed4bb501cbd17194b3cace1dc2126f5b619cf068a726b98192a0fde74ae9"},
+    {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
+    {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
 ]
 markdown = [
     {file = "Markdown-3.3.6-py3-none-any.whl", hash = "sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ mkdocstrings = "^0.17.0"
 mkdocs-material = "^8.0.5"
 mkdocs-autorefs = "^0.3.1"
 mkdocs-coverage = "^0.2.4"
+Jinja2 = "3.0.3"  # older versions have breaking changes for `mike`
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
add empty `py.typed` file so that mypy will know to use our type annotations (following PEP-561)