### PR TITLE
Fix recipe tests

### DIFF
--- a/databooks/affirm.py
+++ b/databooks/affirm.py
@@ -69,6 +69,7 @@ _ALLOWED_NODES = (
     ast.slice,
     ast.Str,
     ast.Sub,
+    ast.Subscript,
     ast.Tuple,
     ast.UAdd,
     ast.UnaryOp,
@@ -141,12 +142,12 @@ class DatabooksParser(ast.NodeVisitor):
 
     def visit_Attribute(self, node: ast.Attribute) -> None:
         """Allow attributes for Pydantic fields only."""
-        if not isinstance(node.value, (ast.Attribute, ast.Name)):
+        if not isinstance(node.value, (ast.Attribute, ast.Name, ast.Subscript)):
             raise ValueError(
-                "Expected attribute to be one of `ast.Name` or `ast.Attribute`, got"
-                f" `ast.{type(node.value).__name__}`"
+                "Expected attribute to be one of `ast.Name`, `ast.Attribute` or"
+                f" `ast.Subscript`, got `ast.{type(node.value).__name__}`."
             )
-        if not isinstance(node.value, ast.Attribute):
+        if isinstance(node.value, ast.Name):
             obj = self.names[node.value.id]
             allowed_attrs = dict(obj).keys() if isinstance(obj, DatabooksBase) else ()
             if node.attr not in allowed_attrs:

--- a/databooks/recipes.py
+++ b/databooks/recipes.py
@@ -37,8 +37,8 @@ class CookBook:
         description="Assert that there is at least one code cell with tags.",
     )
     max_cells = RecipeInfo(
-        src="len(nb.cells) < 128",
-        description="Assert that there are less than 128 cells in the notebook.",
+        src="len(nb.cells) < 64",
+        description="Assert that there are less than 64 cells in the notebook.",
     )
     startswith_md = RecipeInfo(
         src="nb.cells[0].cell_type == 'markdown'",

--- a/docs/usage/overview.md
+++ b/docs/usage/overview.md
@@ -204,8 +204,8 @@ cog.out("\n".join(DOC_TEMPLATE.format(recipe=recipe) for recipe in recipe_docs))
 - **Source:** `any(getattr(cell.metadata, 'tags', []) for cell in code_cells)`
 
 #### `max-cells`
-- **Description:** Assert that there are less than 128 cells in the notebook.
-- **Source:** `len(nb.cells) < 128`
+- **Description:** Assert that there are less than 64 cells in the notebook.
+- **Source:** `len(nb.cells) < 64`
 
 #### `no-empty-code`
 - **Description:** Assert that there are no empty code cells in the notebook.

--- a/tests/files/bad-demo.ipynb
+++ b/tests/files/bad-demo.ipynb
@@ -89,6 +89,898 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a7eb1351-e7d0-43a6-8ac8-ca87e3b18a3c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from random import random  # cell with tags"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca845473-b7df-4e79-9843-e15abb07ac6f",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# `databooks` demo!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "83981d4c-0ac0-496f-a585-fa4a9e4d2fe3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.4024069739399214"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "random()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0dceb807-a706-444c-9274-068a1d1d85da",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "notebooks + git ❤️\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"notebooks + git ❤️\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4b01f9b5-cbf7-4c54-b40b-3c41ce1b60c0",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (1516912967.py, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  Input \u001b[0;32mIn [6]\u001b[0;36m\u001b[0m\n\u001b[0;31m    throw error\u001b[0m\n\u001b[0m          ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "throw error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d5276d9-f9a2-497d-9cbe-4a2c96a65de9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "067a9c93-a632-4637-b96f-16eb3b1e6695",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from random import random  # cell with tags"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9e11eed-97c9-49ba-809e-77b028006647",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# `databooks` demo!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5a858ec7-b90a-4a93-bb98-e95ec70163c3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.4024069739399214"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "random()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8bd21b89-4535-4809-8a21-7b7aa90f6fe6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "notebooks + git ❤️\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"notebooks + git ❤️\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "96c4eb9f-104c-498a-ae28-51796cdb4dbe",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (1516912967.py, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  Input \u001b[0;32mIn [6]\u001b[0;36m\u001b[0m\n\u001b[0;31m    throw error\u001b[0m\n\u001b[0m          ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "throw error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3f7d405-2235-4430-a413-143cac9f23ad",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f118cb1f-8b9d-4701-8f9d-93f1eade3e9c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from random import random  # cell with tags"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3b2babe-682a-4105-9e53-dfc7ae803dc4",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# `databooks` demo!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "73b64f77-cf7c-4149-819e-9810b07248f6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.4024069739399214"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "random()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d375570e-689b-4c0d-b1a0-55f833b1f984",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "notebooks + git ❤️\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"notebooks + git ❤️\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a39dad92-536b-4ef6-a43b-c1fd7cdbe3ac",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (1516912967.py, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  Input \u001b[0;32mIn [6]\u001b[0;36m\u001b[0m\n\u001b[0;31m    throw error\u001b[0m\n\u001b[0m          ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "throw error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98ca17d1-1e81-4bc5-84db-449568daf40c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3eb26b21-1996-4092-858d-130830c31c9c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from random import random  # cell with tags"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a391a0c-e912-40eb-9f90-ac35dc566a24",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# `databooks` demo!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "61940022-4c56-4d78-b194-a54eebb0c278",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.4024069739399214"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "random()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "68580709-a316-4bb9-afd6-57b19194b262",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "notebooks + git ❤️\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"notebooks + git ❤️\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "49907803-b772-459c-b703-684444dee0e3",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (1516912967.py, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  Input \u001b[0;32mIn [6]\u001b[0;36m\u001b[0m\n\u001b[0;31m    throw error\u001b[0m\n\u001b[0m          ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "throw error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "893c2f42-570e-427c-9ba5-8f58681a6860",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2bdf9419-9568-41a2-bb76-ddff504b33be",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from random import random  # cell with tags"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2233bb66-73ca-4337-a307-6aeec8d1afdf",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# `databooks` demo!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b3a0cb36-4f8d-467a-bb22-d08015f82321",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.4024069739399214"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "random()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "eb194424-e3ba-4d51-b856-5401b099fbb6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "notebooks + git ❤️\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"notebooks + git ❤️\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "28527125-d542-4612-bddb-3ff3c0852719",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (1516912967.py, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  Input \u001b[0;32mIn [6]\u001b[0;36m\u001b[0m\n\u001b[0;31m    throw error\u001b[0m\n\u001b[0m          ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "throw error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b1e192fd-6bc5-4052-9e46-500c4583c51f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from random import random  # cell with tags"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4442fce-c320-4e6d-9c03-e000e4928e35",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# `databooks` demo!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6bc5ffca-8a69-4772-8735-ee9270f623d3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.4024069739399214"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "random()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "47eae3b3-2608-4206-8c41-300175928398",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "notebooks + git ❤️\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"notebooks + git ❤️\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d5976e67-9e91-4a06-9fea-478e831d9322",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (1516912967.py, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  Input \u001b[0;32mIn [6]\u001b[0;36m\u001b[0m\n\u001b[0;31m    throw error\u001b[0m\n\u001b[0m          ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "throw error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "380fe924-dea4-414f-b82a-a746418972dc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "afb651db-cf2a-41f4-847e-255836986dad",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from random import random  # cell with tags"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f81f1166-8d7f-4157-bbe0-f66039b14b90",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# `databooks` demo!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ffdc02c2-ff6f-4d62-9e83-f6c94e3999de",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.4024069739399214"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "random()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f703f764-d23f-4cf9-a619-07d491cabb16",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "notebooks + git ❤️\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"notebooks + git ❤️\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cd8a0f82-44a4-4d36-a068-8a4307be2d07",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (1516912967.py, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  Input \u001b[0;32mIn [6]\u001b[0;36m\u001b[0m\n\u001b[0;31m    throw error\u001b[0m\n\u001b[0m          ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "throw error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcd269cf-ca39-418d-8418-f3e447b09abe",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "aaa31ae2-e91a-4e57-977d-69d9aa8910bd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from random import random  # cell with tags"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60938b39-a474-444f-9bdb-04fd2496ca06",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# `databooks` demo!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "06b8d5ab-1ba4-45d5-a1ea-65a69217e6a7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.4024069739399214"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "random()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "585adcb3-37f8-4d4e-b4d9-bd9a27da6d6a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "notebooks + git ❤️\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"notebooks + git ❤️\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "bb3f2fbf-8845-4ce8-8987-ee1499f1ca41",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (1516912967.py, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  Input \u001b[0;32mIn [6]\u001b[0;36m\u001b[0m\n\u001b[0;31m    throw error\u001b[0m\n\u001b[0m          ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "throw error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "398be618-b7b2-4f5a-8fbe-862dc91530ad",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7a8615c5-2954-4488-bbfa-bb03fd4a044a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from random import random  # cell with tags"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2c18368-83c3-4023-9ffc-c204ee0a7f33",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# `databooks` demo!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "99bef853-dcfb-4daf-95e4-cc118ab9a287",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.4024069739399214"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "random()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ce7b5a30-b174-4161-bba2-06a4c6cb9693",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "notebooks + git ❤️\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"notebooks + git ❤️\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1edfed0b-b53d-49e9-ad17-26ad371ee570",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (1516912967.py, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  Input \u001b[0;32mIn [6]\u001b[0;36m\u001b[0m\n\u001b[0;31m    throw error\u001b[0m\n\u001b[0m          ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "throw error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0795641-c08e-447d-8bbf-722d21171bea",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "24951197-15c1-4986-9d77-d4dc15d8ebe5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from random import random  # cell with tags"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09bb1636-ee11-4f44-8a70-3c27ce2fb717",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# `databooks` demo!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8cb839ca-d964-4ba4-a968-27ee1ef21053",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.4024069739399214"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "random()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ebbfc094-f250-4e56-99f9-c3fdfb9d727b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "notebooks + git ❤️\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"notebooks + git ❤️\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "aeedeb83-0902-49b8-b78e-e83af337e4ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (1516912967.py, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  Input \u001b[0;32mIn [6]\u001b[0;36m\u001b[0m\n\u001b[0;31m    throw error\u001b[0m\n\u001b[0m          ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "throw error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bbd6959-1792-45d1-b664-f38421f3a3ec",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -107,7 +999,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.13"
   },
   "toc-autonumbering": false,
   "toc-showcode": true,

--- a/tests/files/demo.ipynb
+++ b/tests/files/demo.ipynb
@@ -83,14 +83,6 @@
    "source": [
     "throw error"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3916ae93-d4da-4deb-88d5-fb1c26c83d76",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -109,7 +101,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.13"
   },
   "toc-autonumbering": false,
   "toc-showcode": true,

--- a/tests/files/pyproject.toml
+++ b/tests/files/pyproject.toml
@@ -9,6 +9,7 @@ metadata-head=false
 [tool.databooks.assert]
 expr = ["[c.execution_count for c in exec_cells] == list(range(1, len(exec_cells) + 1))"]
 recipe = ["seq-exec", "has-tags"]
+ignore=[".ipynb_checkpoints/*"]
 
 [tool.databooks.test-config]
 config-default = "config-value"

--- a/tests/test_affirm.py
+++ b/tests/test_affirm.py
@@ -124,8 +124,8 @@ def test_affirm(caplog: LogCaptureFixture) -> None:
             affirm(
                 nb,
                 [
-                    "len(nb.cells) == 6",
-                    "len(code_cells) == 5",
+                    "len(nb.cells) == 5",
+                    "len(code_cells) == 4",
                     "len(md_cells) == 1",
                 ],
             )

--- a/tests/test_data_models/test_notebook.py
+++ b/tests/test_data_models/test_notebook.py
@@ -256,7 +256,7 @@ def test_parse_file() -> None:
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.8.12",
+            "version": "3.8.13",
         },
         **{
             "toc-showtags": False,
@@ -331,14 +331,6 @@ def test_parse_file() -> None:
                 ],
                 execution_count=4,
                 id="53cd4d06-b52e-4fbb-9ae1-d55babe2f3a2",
-            ),
-            Cell(
-                metadata=CellMetadata(),
-                source=[],
-                cell_type="code",
-                outputs=[],
-                execution_count=None,
-                id="3916ae93-d4da-4deb-88d5-fb1c26c83d76",
             ),
         ]
     )

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -45,9 +45,9 @@ class TestCookBookGood:
         assert affirm(nb_path=self.nb, exprs=[recipe]) is True
 
     def test_no_empty_code(self) -> None:
-        """Ensure that the notebook's first cell is a markdown cell."""
+        """Ensure that the notebook contains no empty code cells."""
         recipe = CookBook.no_empty_code.src
-        assert affirm(nb_path=self.nb, exprs=[recipe]) is False
+        assert affirm(nb_path=self.nb, exprs=[recipe]) is True
 
 
 class TestCookBookBad:
@@ -60,36 +60,36 @@ class TestCookBookBad:
             return nb
 
     def test_has_tags(self) -> None:
-        """Ensure that notebook cells have flags."""
+        """Check fail when notebook cells have no flags."""
         recipe = CookBook.has_tags.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False
 
     def test_has_tags_code(self) -> None:
-        """Ensure that the code cells have flags."""
+        """Check fail when code cells have no flags."""
         recipe = CookBook.has_tags_code.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False
 
     def test_max_cells(self) -> None:
-        """Ensure that notebook has less than 128 cells."""
+        """Check fail when notebook has more than 128 cells."""
         recipe = CookBook.max_cells.src
-        assert affirm(nb_path=self.nb, exprs=[recipe]) is True
+        assert affirm(nb_path=self.nb, exprs=[recipe]) is False
 
     def test_seq_exec(self) -> None:
-        """Ensure that the notebook code cells are executed in order."""
+        """Check fail when notebook code cells are executed out of order."""
         recipe = CookBook.seq_exec.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False
 
     def test_seq_increase(self) -> None:
-        """Ensure that the notebook code cells are executed monotonically."""
+        """Check fail when notebook code cells are not executed monotonically."""
         recipe = CookBook.seq_increase.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False
 
     def test_startswith_md(self) -> None:
-        """Ensure that the notebook's first cell is a markdown cell."""
+        """Check fail when notebook's first cell is not a markdown cell."""
         recipe = CookBook.startswith_md.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False
 
     def test_no_empty_code(self) -> None:
-        """Ensure that the notebook's first cell is a markdown cell."""
+        """Check fail when notebook contains empty code cells."""
         recipe = CookBook.no_empty_code.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -41,7 +41,7 @@ class TestCookBookGood:
 
     def test_startswith_md(self) -> None:
         """Ensure that the notebook's first cell is a markdown cell."""
-        recipe = CookBook.seq_increase.src
+        recipe = CookBook.startswith_md.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is True
 
     def test_no_empty_code(self) -> None:
@@ -86,7 +86,7 @@ class TestCookBookBad:
 
     def test_startswith_md(self) -> None:
         """Ensure that the notebook's first cell is a markdown cell."""
-        recipe = CookBook.seq_increase.src
+        recipe = CookBook.startswith_md.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False
 
     def test_no_empty_code(self) -> None:


### PR DESCRIPTION
- Recipes tests had the wrong docstrings
- In some cases the recipe tested did not correspond to the correct test name
- Change `max-cells` to 64
- Update "good" and "bad" notebooks
  - "good" notebook passes all tests
  - "bad" notebook fails all tests
- Allow ast.Subscript (needed for checking if notebook cell is markdown)