### PR TITLE
Add confirm prompt

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
   name: databooks-meta
   description:
     "Remove Jupyter notebook metadata using `databooks`."
-  entry: databooks meta --overwrite
+  entry: databooks meta --yes
   language: python
   minimum_pre_commit_version: 2.9.2
   types: [jupyter]

--- a/databooks/cli.py
+++ b/databooks/cli.py
@@ -11,6 +11,7 @@ from rich.progress import (
     TextColumn,
     TimeElapsedColumn,
 )
+from rich.prompt import Confirm
 from typer import Argument, BadParameter, Context, Exit, Option, Typer, echo
 
 from databooks.affirm import affirm_all
@@ -107,9 +108,7 @@ def meta(
         (),
         help="Other (excluding `execution_counts` and `outputs`) cell fields to keep",
     ),
-    overwrite: bool = Option(
-        False, "--overwrite", "-w", help="Confirm overwrite of files"
-    ),
+    overwrite: bool = Option(False, "--yes", "-y", help="Confirm overwrite of files"),
     check: bool = Option(
         False,
         "--check",
@@ -140,11 +139,16 @@ def meta(
     nb_paths = _check_paths(paths=paths, ignore=ignore)
 
     if not bool(prefix + suffix) and not check:
-        if not overwrite:
-            raise BadParameter(
-                "No prefix nor suffix were passed."
-                " Please specify `--overwrite` or `-w` to overwrite files."
+        overwrite = (
+            Confirm.ask(
+                f"{len(nb_paths)} files may be overwritten"
+                " (no prefix nor suffix was passed). Continue?"
             )
+            if not overwrite
+            else overwrite
+        )
+        if not overwrite:
+            raise Exit()
         else:
             logger.warning(f"{len(nb_paths)} files will be overwritten")
 

--- a/databooks/cli.py
+++ b/databooks/cli.py
@@ -141,7 +141,7 @@ def meta(
     if not bool(prefix + suffix) and not check:
         overwrite = (
             Confirm.ask(
-                f"{len(nb_paths)} files may be overwritten"
+                f"{len(nb_paths)} files will be overwritten"
                 " (no prefix nor suffix was passed). Continue?"
             )
             if not overwrite

--- a/databooks/logging.py
+++ b/databooks/logging.py
@@ -21,7 +21,8 @@ def get_logger(name: str) -> logging.Logger:
 def set_verbose(logger: logging.Logger) -> None:
     """Set logger to DEBUG level when user requests verbosity."""
     verbose_level = logging.DEBUG
-    logger.setLevel(verbose_level)
-    logger.debug(
-        f"Verbose mode: setting log level to {logging.getLevelName(verbose_level)}"
-    )
+    if logger.level < verbose_level:
+        logger.setLevel(logging.DEBUG)
+        logger.debug(
+            f"Verbose mode: setting log level to {logging.getLevelName(verbose_level)}"
+        )

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -143,7 +143,7 @@ $ databooks meta [OPTIONS] PATHS...
 * `--nb-meta-keep TEXT`: Notebook metadata fields to keep  [default: ]
 * `--cell-meta-keep TEXT`: Cells metadata fields to keep  [default: ]
 * `--cell-fields-keep TEXT`: Other (excluding `execution_counts` and `outputs`) cell fields to keep  [default: ]
-* `-w, --overwrite`: Confirm overwrite of files  [default: False]
+* `-y, --yes`: Confirm overwrite of files  [default: False]
 * `--check`: Don't write files but check whether there is unwanted metadata  [default: False]
 * `-v, --verbose`: Log processed files in console  [default: False]
 * `-c, --config PATH`: Get CLI options from configuration file

--- a/tests/files/pyproject.toml
+++ b/tests/files/pyproject.toml
@@ -1,15 +1,15 @@
 [tool.databooks.meta]
-rm-outs=true
-rm_exec=false
-overwrite=true
+rm-outs = true
+rm_exec = false
+overwrite = true
 
 [tool.databooks.fix]
-metadata-head=false
+metadata-head = false
 
 [tool.databooks.assert]
 expr = ["[c.execution_count for c in exec_cells] == list(range(1, len(exec_cells) + 1))"]
 recipe = ["seq-exec", "has-tags"]
-ignore=[".ipynb_checkpoints/*"]
+ignore = [".ipynb_checkpoints/*"]
 
 [tool.databooks.test-config]
 config-default = "config-value"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,8 +147,8 @@ def test_meta__no_confirm(tmpdir: LocalPath) -> None:
 
     assert result.exit_code == 1
     assert JupyterNotebook.parse_file(nb_path) == TestJupyterNotebook().jupyter_notebook
-    assert (
-        result.output == "1 files may be overwritten (no prefix nor suffix was passed)."
+    assert result.output == (
+        "1 files will be overwritten (no prefix nor suffix was passed)."
         " Continue? [y/n]: \nAborted!\n"
     )
 
@@ -163,7 +163,8 @@ def test_meta__confirm(tmpdir: LocalPath) -> None:
     assert result.exit_code == 0
     assert JupyterNotebook.parse_file(nb_path) != TestJupyterNotebook().jupyter_notebook
     assert result.output == (
-        "1 files may be overwritten (no prefix nor suffix was passed). Continue? [y/n]:"
+        "1 files will be overwritten (no prefix nor suffix was passed)."
+        " Continue? [y/n]:"
         "   Removing metadata ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00\n"
     )
 


### PR DESCRIPTION
Add confirm prompt to overwrite files when no prefix/suffix were passed.
Originally we asked to rerun the command with `-w` or `--overwrite` option. Including as a prompt gives less leeway for the user to assume this is a bug/not functioning properly.
The `-w` or `--overwrite` command gets replaced by `-y` or `--yes`.