### PR TITLE
Fix recipes for clean notebooks

### DIFF
--- a/tests/files/clean.ipynb
+++ b/tests/files/clean.ipynb
@@ -1,0 +1,113 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "metadata": {},
+  "cells": [
+    {
+      "metadata": {},
+      "source": [
+        "# `databooks` demo!"
+      ],
+      "cell_type": "markdown"
+    },
+    {
+      "metadata": {},
+      "source": [
+        "random()"
+      ],
+      "cell_type": "code",
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.8025984025011855"
+            ]
+          },
+          "execution_count": 2,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "execution_count": null
+    },
+    {
+      "metadata": {},
+      "source": [
+        "from random import random"
+      ],
+      "cell_type": "code",
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "metadata": {},
+      "source": [
+        "print(\"It helps with resolving git conflicts but also avoiding them in the first place! \ud83c\udf89\")"
+      ],
+      "cell_type": "code",
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "It helps with resolving git conflicts but also avoiding them in the first place! \ud83c\udf89\n"
+          ]
+        }
+      ],
+      "execution_count": null
+    },
+    {
+      "metadata": {},
+      "source": [
+        "vals = range(1,4)"
+      ],
+      "cell_type": "code",
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "metadata": {},
+      "source": [
+        "for v in vals:\n",
+        "    print(v)"
+      ],
+      "cell_type": "code",
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "1\n",
+            "2\n",
+            "3\n"
+          ]
+        }
+      ],
+      "execution_count": null
+    },
+    {
+      "metadata": {},
+      "source": [
+        "print(\"As easy as running `databooks fix .`\")"
+      ],
+      "cell_type": "code",
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "As easy as running `databooks fix .`\n"
+          ]
+        }
+      ],
+      "execution_count": null
+    },
+    {
+      "metadata": {},
+      "source": [],
+      "cell_type": "code",
+      "outputs": [],
+      "execution_count": null
+    }
+  ]
+}

--- a/tests/test_affirm.py
+++ b/tests/test_affirm.py
@@ -41,6 +41,12 @@ class TestSafeEval:
         parser = DatabooksParser(n=[1, 2, 3])
         assert parser.safe_eval("[i+1 for i in n]") == [2, 3, 4]
 
+    def test_nested_comprehension(self) -> None:
+        """Variables in nested expressions should be valid names."""
+        parser = DatabooksParser(m=[1, 2], n=[3, 4], o=[1, -1])
+        res_eval = parser.safe_eval("[(i+j)*k for j in m for i in n for k in o]")
+        assert res_eval == [4, -4, 5, -5, 5, -5, 6, -6]
+
     def test_multiply(self) -> None:
         """Multiplications are valid."""
         parser = DatabooksParser()

--- a/tests/test_affirm.py
+++ b/tests/test_affirm.py
@@ -85,6 +85,21 @@ class TestSafeEval:
         parser = DatabooksParser(model=DatabooksBase(a=DatabooksBase(b=2)))
         assert parser.safe_eval("model.a.b") == 2
 
+    def test_nested_attributes_comprehensions(self) -> None:
+        """Nested attributes from Pydantic fields in nested comprehensions are valid."""
+        parser = DatabooksParser(
+            l1=[
+                DatabooksBase(a=DatabooksBase(b=1)),
+                DatabooksBase(a=DatabooksBase(b=2)),
+            ],
+            l2=[
+                DatabooksBase(a=DatabooksBase(b=3)),
+                DatabooksBase(a=DatabooksBase(b=4)),
+            ],
+        )
+        res_eval = parser.safe_eval("[m1.a.b+m2.a.b for m1 in l1 for m2 in l2]")
+        assert res_eval == [4, 5, 5, 6]
+
     def test_eval(self) -> None:
         """Trying accessing built-in `eval` raises error."""
         parser = DatabooksParser()

--- a/tests/test_affirm.py
+++ b/tests/test_affirm.py
@@ -42,8 +42,8 @@ class TestSafeEval:
         assert parser.safe_eval("[i+1 for i in n]") == [2, 3, 4]
 
     def test_nested_comprehension(self) -> None:
-        """Variables in nested expressions should be valid names."""
-        parser = DatabooksParser(m=[1, 2], n=[3, 4], o=[1, -1])
+        """Variables in nested iterables should be valid."""
+        parser = DatabooksParser(m=[1, 2], n=[3, 4], o={1: 10, -1: -10})
         res_eval = parser.safe_eval("[(i+j)*k for j in m for i in n for k in o]")
         assert res_eval == [4, -4, 5, -5, 5, -5, 6, -6]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -214,10 +214,10 @@ def test_assert__config(caplog: LogCaptureFixture) -> None:
         )
     logs = list(caplog.records)
     assert result.exit_code == 1
-    assert len(logs) == 3
+    assert len(logs) == 4
     assert (
         logs[-1].message
-        == "Found issues in notebook metadata for 1 out of 2 notebooks."
+        == "Found issues in notebook metadata for 2 out of 3 notebooks."
     )
 
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -49,6 +49,12 @@ class TestCookBookGood:
         recipe = CookBook.no_empty_code.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is True
 
+    def test_seq_exec__clean(self) -> None:
+        """If no cells are executed then no cells are executed out of order."""
+        recipe = CookBook.seq_exec.src
+        with resources.path("tests.files", "clean.ipynb") as nb:
+            assert affirm(nb_path=nb, exprs=[recipe]) is True
+
 
 class TestCookBookBad:
     """Ensure desired effect for recipes."""
@@ -93,9 +99,3 @@ class TestCookBookBad:
         """Check failure when notebook contains empty code cells."""
         recipe = CookBook.no_empty_code.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False
-
-    def test_seq_exec__clean(self) -> None:
-        """Check failure when notebook cells are not executed."""
-        recipe = CookBook.seq_exec.src
-        with resources.path("tests.files", "clean.ipynb") as nb:
-            assert affirm(nb_path=nb, exprs=[recipe]) is False

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -49,12 +49,6 @@ class TestCookBookGood:
         recipe = CookBook.no_empty_code.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is True
 
-    def test_error(self) -> None:
-        """Ensure that the notebook's first cell is a markdown cell."""
-        recipe = CookBook.seq_exec.src
-        with resources.path("tests.files", "doesnt_assert.ipynb") as nb:
-            assert affirm(nb_path=nb, exprs=[recipe]) is True
-
 
 class TestCookBookBad:
     """Ensure desired effect for recipes."""
@@ -66,36 +60,42 @@ class TestCookBookBad:
             return nb
 
     def test_has_tags(self) -> None:
-        """Check fail when notebook cells have no flags."""
+        """Check failure when notebook cells have no flags."""
         recipe = CookBook.has_tags.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False
 
     def test_has_tags_code(self) -> None:
-        """Check fail when code cells have no flags."""
+        """Check failure when code cells have no flags."""
         recipe = CookBook.has_tags_code.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False
 
     def test_max_cells(self) -> None:
-        """Check fail when notebook has more than 128 cells."""
+        """Check failure when notebook has more than 128 cells."""
         recipe = CookBook.max_cells.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False
 
     def test_seq_exec(self) -> None:
-        """Check fail when notebook code cells are executed out of order."""
+        """Check failure when notebook code cells are executed out of order."""
         recipe = CookBook.seq_exec.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False
 
     def test_seq_increase(self) -> None:
-        """Check fail when notebook code cells are not executed monotonically."""
+        """Check failure when notebook code cells are not executed monotonically."""
         recipe = CookBook.seq_increase.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False
 
     def test_startswith_md(self) -> None:
-        """Check fail when notebook's first cell is not a markdown cell."""
+        """Check failure when notebook's first cell is not a markdown cell."""
         recipe = CookBook.startswith_md.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False
 
     def test_no_empty_code(self) -> None:
-        """Check fail when notebook contains empty code cells."""
+        """Check failure when notebook contains empty code cells."""
         recipe = CookBook.no_empty_code.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is False
+
+    def test_seq_exec__clean(self) -> None:
+        """Check failure when notebook cells are not executed."""
+        recipe = CookBook.seq_exec.src
+        with resources.path("tests.files", "clean.ipynb") as nb:
+            assert affirm(nb_path=nb, exprs=[recipe]) is False

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -49,6 +49,12 @@ class TestCookBookGood:
         recipe = CookBook.no_empty_code.src
         assert affirm(nb_path=self.nb, exprs=[recipe]) is True
 
+    def test_error(self) -> None:
+        """Ensure that the notebook's first cell is a markdown cell."""
+        recipe = CookBook.seq_exec.src
+        with resources.path("tests.files", "doesnt_assert.ipynb") as nb:
+            assert affirm(nb_path=nb, exprs=[recipe]) is True
+
 
 class TestCookBookBad:
     """Ensure desired effect for recipes."""


### PR DESCRIPTION
Clean notebooks would throw error when running recipes.
- `seq_exec` on a clean notebook would throw errors if there were no executed code cells

Change the way we access attributes - for comprehensions, dynamically load the variables as an iterable. Go through each element in the iterable and check that the attributes of the element are one of the keys for DatabooksBase objects.

- Can only access attributes of DatabooksBase objects
- Can only access the same attributes we'd get from `dict(obj).keys()`

Add some extra tests to ensure proper functionalities.