### PR TITLE
Use specific cell types (code, raw, or markdown)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,9 @@ repos:
     hooks:
       - id: flake8
         files: (databooks/|tests/)
-        additional_dependencies: [flake8-docstrings==1.6.0]
+        additional_dependencies:
+          - flake8-docstrings==1.6.0
+          - flake8-print==5.0.0
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.942
     hooks:

--- a/databooks/data_models/base.py
+++ b/databooks/data_models/base.py
@@ -56,7 +56,7 @@ def resolve(
     """
     Resolve differences for 'diff models'.
 
-    Return instance alike the parent class `databooks.data_models.Cell.DatabooksBase`.
+    Return instance alike the parent class `databooks.data_models.base.DatabooksBase`.
     :param model: DiffModel that is to be resolved (self when added as a method to a
      class
     :param keep_first: Whether to keep the information from the prior in the

--- a/databooks/data_models/cell.py
+++ b/databooks/data_models/cell.py
@@ -20,7 +20,7 @@ class CellMetadata(DatabooksBase):
     """Cell metadata. Empty by default but can accept extra fields."""
 
 
-class Cell(DatabooksBase):
+class CellBase(DatabooksBase):
     """
     Jupyter notebook cells.
 
@@ -54,12 +54,12 @@ class Cell(DatabooksBase):
         self, fields: Iterable[str] = (), missing_ok: bool = True, **kwargs: Any
     ) -> None:
         """
-        Remove Cell fields.
+        Remove cell fields.
 
         Similar to `databooks.data_models.base.remove_fields`, but will ignore required
-         fields for `databooks.data_models.notebook.Cell`.
+         fields for `databooks.data_models.notebook.CellBase`.
         """
-        # Ignore required `Cell` fields
+        # Ignore required `CellBase` fields
         cell_fields = self.__fields__  # required fields especified in class definition
         if any(field in fields for field in cell_fields):
             logger.debug(
@@ -69,7 +69,7 @@ class Cell(DatabooksBase):
             )
             fields = [f for f in fields if f not in cell_fields]
 
-        super(Cell, self).remove_fields(fields, missing_ok=missing_ok)
+        super(CellBase, self).remove_fields(fields, missing_ok=missing_ok)
 
         if self.cell_type == "code":
             self.outputs: CellOutputs = (
@@ -92,7 +92,7 @@ class Cell(DatabooksBase):
         Clear cell metadata, execution count, outputs or other desired fields (id, ...).
 
         You can also specify metadata to keep or remove from the `metadata` property of
-         `databooks.data_models.notebook.Cell`.
+         `databooks.data_models.notebook.CellBase`.
         :param cell_metadata_keep: Metadata values to keep - simply pass an empty
          sequence (i.e.: `()`) to remove all extra fields.
         :param cell_metadata_remove: Metadata values to remove
@@ -296,7 +296,7 @@ class CellOutputs(DatabooksBase):
         return self.__root__
 
 
-class CodeCell(Cell):
+class CodeCell(CellBase):
     """Cell of type `code` - defined for rich displaying in terminal."""
 
     outputs: CellOutputs
@@ -323,11 +323,11 @@ class CodeCell(Cell):
     def cell_has_code_type(cls, v: str) -> str:
         """Extract the list values from the __root__ attribute of `CellOutputs`."""
         if v != "code":
-            raise ValueError(f"Expected code of type `code`, got {v}.")
+            raise ValueError(f"Expected code of type `code`, got `{v}`.")
         return v
 
 
-class MarkdownCell(Cell):
+class MarkdownCell(CellBase):
     """Cell of type `markdown` - defined for rich displaying in terminal."""
 
     def __rich_console__(
@@ -344,7 +344,7 @@ class MarkdownCell(Cell):
         return v
 
 
-class RawCell(Cell):
+class RawCell(CellBase):
     """Cell of type `raw` - defined for rich displaying in terminal."""
 
     def __rich_console__(

--- a/databooks/data_models/cell.py
+++ b/databooks/data_models/cell.py
@@ -309,7 +309,7 @@ class CodeCell(CellBase):
         yield Panel(
             Syntax(
                 "".join(self.source) if isinstance(self.source, list) else self.source,
-                "python",
+                getattr(self.metadata, "lang", "text"),
             )
         )
         yield self.outputs

--- a/databooks/data_models/cell.py
+++ b/databooks/data_models/cell.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
 
-from pydantic import PositiveInt, root_validator, validate_model, validator
+from pydantic import PositiveInt, validator
 from rich.console import Console, ConsoleOptions, ConsoleRenderable, RenderResult
 from rich.markdown import Markdown
 from rich.panel import Panel
@@ -38,17 +38,6 @@ class CellBase(DatabooksBase):
             (type(self),) + tuple(v) if isinstance(v, list) else v
             for v in self.__dict__.values()
         )
-
-    def __rich_console__(
-        self, console: Console, options: ConsoleOptions
-    ) -> RenderResult:
-        """Rich display of cell."""
-        _, _, validation_error = validate_model(self.__class__, self.dict())
-        if validation_error:
-            raise validation_error
-        cell_map = {"code": CodeCell, "markdown": MarkdownCell, "raw": RawCell}
-        cell = cell_map[self.cell_type]
-        yield cell(**self.dict())
 
     def remove_fields(
         self, fields: Iterable[str] = (), missing_ok: bool = True, **kwargs: Any
@@ -113,45 +102,6 @@ class CellBase(DatabooksBase):
         self.metadata.remove_fields(cell_metadata_remove)  # type: ignore
 
         self.remove_fields(fields=cell_remove_fields, missing_ok=True)
-
-    @validator("cell_type")
-    def cell_has_valid_type(cls, v: str) -> str:
-        """Check if cell has one of the three predefined types."""
-        valid_cell_types = ("raw", "markdown", "code")
-        if v not in valid_cell_types:
-            raise ValueError(f"Invalid cell type. Must be one of {valid_cell_types}")
-        return v
-
-    @root_validator
-    def code_cell_has_outputs(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        """Check that code cells have outputs."""
-        if values.get("cell_type") == "code" and "outputs" not in values:
-            raise ValueError(
-                f"All code cells must have an `outputs` property, got {values}"
-            )
-        return values
-
-    @root_validator
-    def outputs_are_valid(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        """Check and parse that cell outputs are valid."""
-        outputs = values.get("outputs")
-        if outputs is not None:
-            values["outputs"] = CellOutputs(__root__=outputs)
-        return values
-
-    @root_validator
-    def only_code_cells_have_outputs_and_execution_count(
-        cls, values: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """Check that only code cells have outputs and execution count."""
-        if values.get("cell_type") != "code" and (
-            ("outputs" in values) or ("execution_count" in values)
-        ):
-            raise ValueError(
-                "Found `outputs` or `execution_count` for cell of type"
-                f" `{values['cell_type']}`"
-            )
-        return values
 
 
 class CellStreamOutput(DatabooksBase):
@@ -300,6 +250,7 @@ class CodeCell(CellBase):
     """Cell of type `code` - defined for rich displaying in terminal."""
 
     outputs: CellOutputs
+    cell_type: str = "code"
 
     def __rich_console__(
         self, console: Console, options: ConsoleOptions
@@ -314,11 +265,6 @@ class CodeCell(CellBase):
         )
         yield self.outputs
 
-    @validator("outputs")
-    def get_attr_from_dunder_root(cls, v: CellOutputs) -> List[CellOutputType]:
-        """Extract the list values from the __root__ attribute of `CellOutputs`."""
-        return v.__root__
-
     @validator("cell_type")
     def cell_has_code_type(cls, v: str) -> str:
         """Extract the list values from the __root__ attribute of `CellOutputs`."""
@@ -329,6 +275,8 @@ class CodeCell(CellBase):
 
 class MarkdownCell(CellBase):
     """Cell of type `markdown` - defined for rich displaying in terminal."""
+
+    cell_type: str = "markdown"
 
     def __rich_console__(
         self, console: Console, options: ConsoleOptions
@@ -346,6 +294,8 @@ class MarkdownCell(CellBase):
 
 class RawCell(CellBase):
     """Cell of type `raw` - defined for rich displaying in terminal."""
+
+    cell_type: str = "raw"
 
     def __rich_console__(
         self, console: Console, options: ConsoleOptions

--- a/databooks/data_models/cell.py
+++ b/databooks/data_models/cell.py
@@ -57,7 +57,7 @@ class CellBase(DatabooksBase):
         Remove cell fields.
 
         Similar to `databooks.data_models.base.remove_fields`, but will ignore required
-         fields for `databooks.data_models.notebook.CellBase`.
+         fields for cell type.
         """
         # Ignore required `CellBase` fields
         cell_fields = self.__fields__  # required fields especified in class definition
@@ -92,7 +92,7 @@ class CellBase(DatabooksBase):
         Clear cell metadata, execution count, outputs or other desired fields (id, ...).
 
         You can also specify metadata to keep or remove from the `metadata` property of
-         `databooks.data_models.notebook.CellBase`.
+         `databooks.data_models.cell.CellBase`.
         :param cell_metadata_keep: Metadata values to keep - simply pass an empty
          sequence (i.e.: `()`) to remove all extra fields.
         :param cell_metadata_remove: Metadata values to remove

--- a/databooks/data_models/notebook.py
+++ b/databooks/data_models/notebook.py
@@ -187,6 +187,10 @@ class JupyterNotebook(DatabooksBase, extra=Extra.forbid):
         self, console: Console, options: ConsoleOptions
     ) -> RenderResult:
         """Rich display notebook."""
+        nb_lang = self.metadata.dict().get("kernelspec", {}).get("language", "text")
+        for cell in self.cells:
+            if isinstance(cell, CodeCell):
+                cell.metadata = CellMetadata(**cell.metadata.dict(), lang=nb_lang)
         yield self.cells
 
     @classmethod

--- a/databooks/data_models/notebook.py
+++ b/databooks/data_models/notebook.py
@@ -26,11 +26,11 @@ from databooks.data_models.base import BaseCells, DatabooksBase
 from databooks.data_models.cell import CellMetadata, CodeCell, MarkdownCell, RawCell
 from databooks.logging import get_logger
 
-CellBase = Union[CodeCell, RawCell, MarkdownCell]
+Cell = Union[CodeCell, RawCell, MarkdownCell]
 logger = get_logger(__file__)
 
 
-T = TypeVar("T", CellBase, Tuple[List[CellBase], List[CellBase]])
+T = TypeVar("T", Cell, Tuple[List[Cell], List[Cell]])
 
 
 class Cells(GenericModel, BaseCells[T]):
@@ -52,8 +52,8 @@ class Cells(GenericModel, BaseCells[T]):
         return (el for el in self.data)
 
     def __sub__(
-        self: Cells[CellBase], other: Cells[CellBase]
-    ) -> Cells[Tuple[List[CellBase], List[CellBase]]]:
+        self: Cells[Cell], other: Cells[Cell]
+    ) -> Cells[Tuple[List[Cell], List[Cell]]]:
         """Return the difference using `difflib.SequenceMatcher`."""
         if type(self) != type(other):
             raise TypeError(
@@ -77,7 +77,7 @@ class Cells(GenericModel, BaseCells[T]):
                 f" {n_context} for {len(self)} and {len(other)} cells in"
                 " notebooks."
             )
-        return Cells[Tuple[List[CellBase], List[CellBase]]](
+        return Cells[Tuple[List[Cell], List[Cell]]](
             [
                 # https://github.com/python/mypy/issues/9459
                 tuple((self.data[i1:j1], other.data[i2:j2]))  # type: ignore
@@ -107,11 +107,11 @@ class Cells(GenericModel, BaseCells[T]):
 
     @staticmethod
     def wrap_git(
-        first_cells: List[CellBase],
-        last_cells: List[CellBase],
+        first_cells: List[Cell],
+        last_cells: List[Cell],
         hash_first: Optional[str] = None,
         hash_last: Optional[str] = None,
-    ) -> Sequence[CellBase]:
+    ) -> Sequence[Cell]:
         """Wrap git-diff cells in existing notebook."""
         return [
             MarkdownCell(
@@ -134,13 +134,13 @@ class Cells(GenericModel, BaseCells[T]):
         ]
 
     def resolve(
-        self: Cells[Tuple[List[CellBase], List[CellBase]]],
+        self: Cells[Tuple[List[Cell], List[Cell]]],
         *,
         keep_first_cells: Optional[bool] = None,
         first_id: Optional[str] = None,
         last_id: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[CellBase]:
+    ) -> List[Cell]:
         """
         Resolve differences between `databooks.data_models.notebook.Cells`.
 
@@ -181,7 +181,7 @@ class JupyterNotebook(DatabooksBase, extra=Extra.forbid):
     nbformat: int
     nbformat_minor: int
     metadata: NotebookMetadata
-    cells: Cells[CellBase]
+    cells: Cells[Cell]
 
     def __rich_console__(
         self, console: Console, options: ConsoleOptions

--- a/databooks/data_models/notebook.py
+++ b/databooks/data_models/notebook.py
@@ -6,20 +6,31 @@ from copy import deepcopy
 from difflib import SequenceMatcher
 from itertools import chain
 from pathlib import Path
-from typing import Any, Callable, Generator, List, Optional, Sequence, Tuple, TypeVar
+from typing import (
+    Any,
+    Callable,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 from pydantic import Extra, validate_model
 from pydantic.generics import GenericModel
 from rich.console import Console, ConsoleOptions, RenderResult
 
 from databooks.data_models.base import BaseCells, DatabooksBase
-from databooks.data_models.cell import Cell, CellMetadata
+from databooks.data_models.cell import CellMetadata, CodeCell, MarkdownCell, RawCell
 from databooks.logging import get_logger
 
+CellBase = Union[CodeCell, RawCell, MarkdownCell]
 logger = get_logger(__file__)
 
 
-T = TypeVar("T", Cell, Tuple[List[Cell], List[Cell]])
+T = TypeVar("T", CellBase, Tuple[List[CellBase], List[CellBase]])
 
 
 class Cells(GenericModel, BaseCells[T]):
@@ -41,8 +52,8 @@ class Cells(GenericModel, BaseCells[T]):
         return (el for el in self.data)
 
     def __sub__(
-        self: Cells[Cell], other: Cells[Cell]
-    ) -> Cells[Tuple[List[Cell], List[Cell]]]:
+        self: Cells[CellBase], other: Cells[CellBase]
+    ) -> Cells[Tuple[List[CellBase], List[CellBase]]]:
         """Return the difference using `difflib.SequenceMatcher`."""
         if type(self) != type(other):
             raise TypeError(
@@ -66,7 +77,7 @@ class Cells(GenericModel, BaseCells[T]):
                 f" {n_context} for {len(self)} and {len(other)} cells in"
                 " notebooks."
             )
-        return Cells[Tuple[List[Cell], List[Cell]]](
+        return Cells[Tuple[List[CellBase], List[CellBase]]](
             [
                 # https://github.com/python/mypy/issues/9459
                 tuple((self.data[i1:j1], other.data[i2:j2]))  # type: ignore
@@ -96,46 +107,40 @@ class Cells(GenericModel, BaseCells[T]):
 
     @staticmethod
     def wrap_git(
-        first_cells: List[Cell],
-        last_cells: List[Cell],
+        first_cells: List[CellBase],
+        last_cells: List[CellBase],
         hash_first: Optional[str] = None,
         hash_last: Optional[str] = None,
-    ) -> List[Cell]:
+    ) -> Sequence[CellBase]:
         """Wrap git-diff cells in existing notebook."""
-        return (
-            [
-                Cell(
-                    metadata=CellMetadata(git_hash=hash_first),
-                    source=[f"`<<<<<<< {hash_first}`"],
-                    cell_type="markdown",
-                )
-            ]
-            + first_cells
-            + [
-                Cell(
-                    source=["`=======`"],
-                    cell_type="markdown",
-                    metadata=CellMetadata(),
-                )
-            ]
-            + last_cells
-            + [
-                Cell(
-                    metadata=CellMetadata(git_hash=hash_last),
-                    source=[f"`>>>>>>> {hash_last}`"],
-                    cell_type="markdown",
-                )
-            ]
-        )
+        return [
+            MarkdownCell(
+                metadata=CellMetadata(git_hash=hash_first),
+                source=[f"`<<<<<<< {hash_first}`"],
+                cell_type="markdown",
+            ),
+            *first_cells,
+            MarkdownCell(
+                source=["`=======`"],
+                cell_type="markdown",
+                metadata=CellMetadata(),
+            ),
+            *last_cells,
+            MarkdownCell(
+                metadata=CellMetadata(git_hash=hash_last),
+                source=[f"`>>>>>>> {hash_last}`"],
+                cell_type="markdown",
+            ),
+        ]
 
     def resolve(
-        self: Cells[Tuple[List[Cell], List[Cell]]],
+        self: Cells[Tuple[List[CellBase], List[CellBase]]],
         *,
         keep_first_cells: Optional[bool] = None,
         first_id: Optional[str] = None,
         last_id: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Cell]:
+    ) -> List[CellBase]:
         """
         Resolve differences between `databooks.data_models.notebook.Cells`.
 
@@ -176,7 +181,7 @@ class JupyterNotebook(DatabooksBase, extra=Extra.forbid):
     nbformat: int
     nbformat_minor: int
     metadata: NotebookMetadata
-    cells: Cells[Cell]
+    cells: Cells[CellBase]
 
     def __rich_console__(
         self, console: Console, options: ConsoleOptions
@@ -227,7 +232,7 @@ class JupyterNotebook(DatabooksBase, extra=Extra.forbid):
          sequence (i.e.: `()`) to remove all extra fields.
         :param notebook_metadata_remove: Metadata values to remove
         :param cell_kwargs: keyword arguments to be passed to each cell's
-         `databooks.data_models.Cell.clear_metadata`
+         `databooks.data_models.cell.CellBase.clear_metadata`
         :return:
         """
         nargs = sum(

--- a/databooks/metadata.py
+++ b/databooks/metadata.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Callable, List, Optional, Sequence
 
 from databooks import JupyterNotebook
-from databooks.data_models.cell import Cell
+from databooks.data_models.cell import CellBase
 from databooks.logging import get_logger, set_verbose
 
 logger = get_logger(__file__)
@@ -46,7 +46,7 @@ def clear(
 
     # Get fields to remove from cells and keep notebook schema
     cell_fields = {field for cell in notebook.cells for field, _ in cell if field}
-    cell_fields_keep = list(cell_fields_keep) + list(Cell.__fields__)
+    cell_fields_keep = list(cell_fields_keep) + list(CellBase.__fields__)
 
     cell_remove_fields = [
         field for field in cell_fields if field not in cell_fields_keep

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ from typer.core import TyperCommand
 from typer.testing import CliRunner
 
 from databooks.cli import _config_callback, app
-from databooks.data_models.cell import Cell, CellMetadata, CellOutputs
+from databooks.data_models.cell import CellBase, CellMetadata, CellOutputs
 from databooks.data_models.notebook import JupyterNotebook, NotebookMetadata
 from databooks.git_utils import get_conflict_blobs
 from databooks.version import __version__
@@ -109,7 +109,15 @@ def test_meta__config(tmpdir: LocalPath) -> None:
 
     assert result.exit_code == 0
     assert nb_read != nb_write, "Notebook was not overwritten"
-    assert all(c.outputs == CellOutputs(__root__=[]) for c in nb_write.cells)
+    assert all(
+        c.outputs
+        == CellOutputs(
+            __root__=[
+                {"name": "stdout", "output_type": "stream", "text": ["test text\n"]}
+            ]
+        )
+        for c in nb_write.cells
+    )
     assert all(c.execution_count is not None for c in nb_write.cells)
 
     # Override config file arguments
@@ -233,7 +241,7 @@ def test_fix(tmpdir: LocalPath) -> None:
         another_field_to_remove="another field",
     )
 
-    extra_cell = Cell(
+    extra_cell = CellBase(
         cell_type="raw",
         metadata=CellMetadata(random_meta=["meta"]),
         source="extra",
@@ -273,18 +281,18 @@ def test_fix(tmpdir: LocalPath) -> None:
     assert fixed_notebook.nbformat == notebook_1.nbformat
     assert fixed_notebook.nbformat_minor == notebook_1.nbformat_minor
     assert fixed_notebook.cells == notebook_1.cells + [
-        Cell(
+        CellBase(
             metadata=CellMetadata(git_hash=id_main),
             source=[f"`<<<<<<< {id_main}`"],
             cell_type="markdown",
         ),
-        Cell(
+        CellBase(
             source=["`=======`"],
             cell_type="markdown",
             metadata=CellMetadata(),
         ),
         extra_cell,
-        Cell(
+        CellBase(
             metadata=CellMetadata(git_hash=id_other),
             source=[f"`>>>>>>> {id_other}`"],
             cell_type="markdown",
@@ -307,7 +315,7 @@ def test_fix__config(tmpdir: LocalPath) -> None:
         another_field_to_remove="another field",
     )
 
-    extra_cell = Cell(
+    extra_cell = CellBase(
         cell_type="raw",
         metadata=CellMetadata(random_meta=["meta"]),
         source="extra",
@@ -348,18 +356,18 @@ def test_fix__config(tmpdir: LocalPath) -> None:
     assert fixed_notebook.nbformat == notebook_2.nbformat
     assert fixed_notebook.nbformat_minor == notebook_2.nbformat_minor
     assert fixed_notebook.cells == notebook_1.cells + [
-        Cell(
+        CellBase(
             metadata=CellMetadata(git_hash=id_main),
             source=[f"`<<<<<<< {id_main}`"],
             cell_type="markdown",
         ),
-        Cell(
+        CellBase(
             source=["`=======`"],
             cell_type="markdown",
             metadata=CellMetadata(),
         ),
         extra_cell,
-        Cell(
+        CellBase(
             metadata=CellMetadata(git_hash=id_other),
             source=[f"`>>>>>>> {id_other}`"],
             cell_type="markdown",

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from py._path.local import LocalPath
 
 from databooks.conflicts import path2conflicts
-from databooks.data_models.cell import Cell, CellMetadata
+from databooks.data_models.cell import CellBase, CellMetadata
 from databooks.data_models.notebook import NotebookMetadata
 from tests.test_data_models.test_notebook import TestJupyterNotebook
 from tests.test_git_utils import ConflictFile, init_repo_conflicts
@@ -21,7 +21,7 @@ def test_path2diff(tmpdir: LocalPath) -> None:
         field_to_remove=["Field to remove"],
         another_field_to_remove="another field",
     )
-    extra_cell = Cell(
+    extra_cell = CellBase(
         cell_type="raw",
         metadata=CellMetadata(random_meta=["meta"]),
         source="extra",

--- a/tests/test_data_models/test_notebook.py
+++ b/tests/test_data_models/test_notebook.py
@@ -18,7 +18,7 @@ from databooks.data_models.cell import (
     RawCell,
 )
 from databooks.data_models.notebook import (
-    CellBase,
+    Cell,
     Cells,
     JupyterNotebook,
     NotebookMetadata,
@@ -131,13 +131,13 @@ class TestCell:
 
     def test_cells_sub(self) -> None:
         """Get the diff from different `Cells`."""
-        dl1 = Cells[CellBase]([self.cell])
-        dl2 = Cells[CellBase]([self.cell] * 2)
+        dl1 = Cells[Cell]([self.cell])
+        dl2 = Cells[Cell]([self.cell] * 2)
 
         diff = dl1 - dl2
 
-        assert type(dl1) == type(dl2) == Cells[CellBase]
-        assert type(diff) == Cells[Tuple[List[CellBase], List[CellBase]]]
+        assert type(dl1) == type(dl2) == Cells[Cell]
+        assert type(diff) == Cells[Tuple[List[Cell], List[Cell]]]
         assert diff == Cells(  # type: ignore
             [([self.cell], [self.cell]), ([], [self.cell])]
         )

--- a/tests/test_data_models/test_notebook.py
+++ b/tests/test_data_models/test_notebook.py
@@ -9,8 +9,20 @@ import pytest
 from _pytest.logging import LogCaptureFixture
 from py._path.local import LocalPath
 
-from databooks.data_models.cell import Cell, CellMetadata, CellOutputs
-from databooks.data_models.notebook import Cells, JupyterNotebook, NotebookMetadata
+from databooks.data_models.cell import (
+    CellMetadata,
+    CellOutputs,
+    CellStreamOutput,
+    CodeCell,
+    MarkdownCell,
+    RawCell,
+)
+from databooks.data_models.notebook import (
+    CellBase,
+    Cells,
+    JupyterNotebook,
+    NotebookMetadata,
+)
 
 
 class TestNotebookMetadata:
@@ -63,9 +75,9 @@ class TestCell:
         return CellMetadata(field_to_remove="Field to remove")
 
     @property
-    def cell(self) -> Cell:
-        """`Cell` property to test on."""
-        return Cell(
+    def cell(self) -> CodeCell:
+        """`CodeCell` property to test on."""
+        return CodeCell(
             cell_type="code",
             metadata=self.cell_metadata,
             source=["test_source"],
@@ -86,7 +98,7 @@ class TestCell:
         assert metadata == CellMetadata()
 
     def test_clear(self, caplog: LogCaptureFixture) -> None:
-        """Remove metadata specified from notebook `Cell`."""
+        """Remove metadata specified from notebook `CodeCell`."""
         caplog.set_level(logging.DEBUG)
 
         cell = self.cell
@@ -99,27 +111,33 @@ class TestCell:
         )
         logs = list(caplog.records)
 
-        assert cell == Cell(
+        assert cell == CodeCell(
             cell_type="code",
             metadata=CellMetadata(),
-            outputs=[],
+            outputs=CellOutputs(
+                __root__=[
+                    CellStreamOutput(
+                        output_type="stream", name="stdout", text=["test text\n"]
+                    )
+                ]
+            ),
             source=["test_source"],
             execution_count=None,
         )
         assert len(logs) == 1
         assert logs[0].message == (
-            "Ignoring removal of required fields ['source'] in `Cell`."
+            "Ignoring removal of required fields ['outputs', 'source'] in `CodeCell`."
         )
 
     def test_cells_sub(self) -> None:
         """Get the diff from different `Cells`."""
-        dl1 = Cells[Cell]([self.cell])
-        dl2 = Cells[Cell]([self.cell] * 2)
+        dl1 = Cells[CellBase]([self.cell])
+        dl2 = Cells[CellBase]([self.cell] * 2)
 
         diff = dl1 - dl2
 
-        assert type(dl1) == type(dl2) == Cells[Cell]
-        assert type(diff) == Cells[Tuple[List[Cell], List[Cell]]]
+        assert type(dl1) == type(dl2) == Cells[CellBase]
+        assert type(diff) == Cells[Tuple[List[CellBase], List[CellBase]]]
         assert diff == Cells(  # type: ignore
             [([self.cell], [self.cell]), ([], [self.cell])]
         )
@@ -136,11 +154,14 @@ class TestCell:
             metadata=self.cell_metadata,
             source=["test_source"],
             execution_count=1,
-            outputs=[],
+            outputs=[
+                {"name": "stdout", "output_type": "stream", "text": ["test text\n"]}
+            ],
         )
         assert len(logs) == 1
         assert logs[0].message == (
-            "Ignoring removal of required fields ['cell_type'] in `Cell`."
+            "Ignoring removal of required fields ['cell_type', 'outputs'] in"
+            " `CodeCell`."
         )
 
 
@@ -168,7 +189,14 @@ class TestJupyterNotebook(TestNotebookMetadata, TestCell):
 
         assert all(cell.metadata == CellMetadata() for cell in notebook.cells)
         assert all(
-            cell.outputs == CellOutputs(__root__=[])
+            cell.outputs
+            == CellOutputs(
+                __root__=[
+                    CellStreamOutput(
+                        output_type="stream", name="stdout", text=["test text\n"]
+                    )
+                ]
+            )
             for cell in notebook.cells
             if cell.cell_type == "code"
         )
@@ -194,7 +222,7 @@ class TestJupyterNotebook(TestNotebookMetadata, TestCell):
             field_to_remove=["Field to remove"],
             another_field_to_remove="another field",
         )
-        extra_cell = Cell(
+        extra_cell = RawCell(
             cell_type="raw",
             metadata=CellMetadata(random_meta=["meta"]),
             source="extra",
@@ -215,18 +243,18 @@ class TestJupyterNotebook(TestNotebookMetadata, TestCell):
         assert diff.resolve(keep_first_cells=False) == notebook
 
         notebook.cells = notebook_1.cells + [
-            Cell(
+            MarkdownCell(
                 metadata=CellMetadata(git_hash=None),
                 source=["`<<<<<<< None`"],
                 cell_type="markdown",
             ),
-            Cell(
+            MarkdownCell(
                 source=["`=======`"],
                 cell_type="markdown",
                 metadata=CellMetadata(),
             ),
             extra_cell,
-            Cell(
+            MarkdownCell(
                 metadata=CellMetadata(git_hash=None),
                 source=["`>>>>>>> None`"],
                 cell_type="markdown",
@@ -266,13 +294,13 @@ def test_parse_file() -> None:
     )
     assert notebook.cells == Cells(
         [
-            Cell(
+            MarkdownCell(
                 metadata=CellMetadata(tags=[]),
                 source=["# `databooks` demo!"],
                 cell_type="markdown",
                 id="9adc7c77-95f1-4cb9-b987-1411e28f2976",
             ),
-            Cell(
+            CodeCell(
                 metadata=CellMetadata(tags=["random-tag"]),
                 source=["from random import random  # cell with tags"],
                 cell_type="code",
@@ -280,7 +308,7 @@ def test_parse_file() -> None:
                 execution_count=1,
                 id="6a6eafec-a799-455b-8c1b-fd43a0a1f3ca",
             ),
-            Cell(
+            CodeCell(
                 metadata=CellMetadata(tags=[]),
                 source=["random()"],
                 cell_type="code",
@@ -295,7 +323,7 @@ def test_parse_file() -> None:
                 execution_count=2,
                 id="8b852d3e-5482-4feb-8bd1-e902ed6ecaff",
             ),
-            Cell(
+            CodeCell(
                 metadata=CellMetadata(),
                 source=['print("notebooks + git ❤️")'],
                 cell_type="code",
@@ -309,7 +337,7 @@ def test_parse_file() -> None:
                 execution_count=3,
                 id="4dcb36c4-d671-4ec9-9bff-87857b3f718a",
             ),
-            Cell(
+            CodeCell(
                 metadata=CellMetadata(),
                 source=["throw error"],
                 cell_type="code",
@@ -331,7 +359,7 @@ def test_parse_file() -> None:
                 execution_count=4,
                 id="53cd4d06-b52e-4fbb-9ae1-d55babe2f3a2",
             ),
-            Cell(
+            RawCell(
                 metadata=CellMetadata(),
                 source=["This is a raw cell! 🚀"],
                 cell_type="raw",

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -59,7 +59,12 @@ def test_metadata_clear(tmpdir: LocalPath) -> None:
     assert len(nb_write.cells) == len(nb_read.cells)
     assert all(cell.metadata == CellMetadata() for cell in nb_write.cells)
     assert all(
-        cell.outputs == CellOutputs(__root__=[])
+        cell.outputs
+        == CellOutputs(
+            __root__=[
+                {"name": "stdout", "output_type": "stream", "text": ["test text\n"]}
+            ]
+        )
         for cell in nb_write.cells
         if cell.cell_type == "code"
     )


### PR DESCRIPTION
We defined the specific types with the different specific requirements.

Favor specific cell types instead of the the "generic base cell".