### PR TITLE
Bugfix: config not found

### DIFF
--- a/databooks/cli.py
+++ b/databooks/cli.py
@@ -46,7 +46,7 @@ def _help_callback(ctx: Context, show_help: Optional[bool]) -> None:
 def _config_callback(ctx: Context, config_path: Optional[Path]) -> Optional[Path]:
     """Get config file and inject values into context to override default args."""
     target_paths = expand_paths(
-        paths=[Path(p) for p in ctx.params.get("paths", ())], rglob="*"
+        paths=[Path(p).resolve() for p in ctx.params.get("paths", ())]
     )
     config_path = (
         get_config(

--- a/databooks/common.py
+++ b/databooks/common.py
@@ -53,12 +53,13 @@ def find_obj(
 
     :param obj_name: File name to locate
     :param start: Start (parent) directory
-    :param finish: Finish (child) directory
+    :param finish: Finish (child) path
     :param is_dir: Whether object is a directory or a file
     :return: File path
     """
-    if not start.is_dir() or not finish.is_dir():
-        raise ValueError("Parameters `start` and `finish` must be directories.")
+    finish = finish if finish.is_dir() else finish.parent
+    if not start.is_dir():
+        raise ValueError("Parameter `start` must be a directory.")
 
     if start.resolve() not in [finish, *finish.resolve().parents]:
         logger.debug(

--- a/databooks/common.py
+++ b/databooks/common.py
@@ -39,10 +39,10 @@ def expand_paths(
 
 
 def find_common_parent(paths: Iterable[Path]) -> Path:
-    """Find common parent amongst several file paths."""
+    """Find common parent amongst several file paths (includes current path)."""
     if not paths:
         raise ValueError(f"Expected non-empty `paths`, got {paths}.")
-    return max(set.intersection(*[set(p.resolve().parents) for p in paths]))
+    return max(set.intersection(*[{*p.resolve().parents, p.resolve()} for p in paths]))
 
 
 def find_obj(

--- a/databooks/config.py
+++ b/databooks/config.py
@@ -15,11 +15,11 @@ logger = get_logger(__file__)
 
 def get_config(target_paths: List[Path], config_filename: str) -> Optional[Path]:
     """Find configuration file from CLI target paths."""
-    common_parent = find_common_parent(paths=target_paths)
+    common_path = find_common_parent(paths=target_paths)
     repo_dir = get_repo().working_dir
 
     return find_obj(
         obj_name=config_filename,
-        start=Path(repo_dir) if repo_dir is not None else Path(common_parent.anchor),
-        finish=common_parent,
+        start=Path(repo_dir) if repo_dir is not None else Path(common_path.anchor),
+        finish=common_path,
     )


### PR DESCRIPTION
When finding the common parent of the files passed (used in finding config files) we don't consider the current path. So running `databooks command path/` in the project root  would not find the config (since search paths included only the one directory above).

We refactor finding these objects to include the current path.