### PR TITLE
Relax typer version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
       - name: Unit tests
         run: |
-          pytest -v
+          pytest -vv
       - name: Coverage report
         run: |
           pytest --cov=./ --cov-report=xml

--- a/poetry.lock
+++ b/poetry.lock
@@ -720,7 +720,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "f5fcf38edb9279cd3746f66601d91e20f7f89b91e9f09169d46bf4b903162c30"
+content-hash = "b965437dce7692142c6f9f0e7dc693a03472d67d8123d1f512dc15563c6b9461"
 
 [metadata.files]
 astunparse = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -629,7 +629,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "typer"
-version = "0.4.2"
+version = "0.6.1"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 category = "main"
 optional = false
@@ -639,10 +639,10 @@ python-versions = ">=3.6"
 click = ">=7.1.1,<9.0.0"
 
 [package.extras]
-all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)"]
+all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)", "rich (>=10.11.0,<13.0.0)"]
 dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
 doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "mdx-include (>=1.4.1,<2.0.0)"]
-test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.910)", "black (>=22.3.0,<23.0.0)", "isort (>=5.0.6,<6.0.0)"]
+test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.910)", "black (>=22.3.0,<23.0.0)", "isort (>=5.0.6,<6.0.0)", "rich (>=10.11.0,<13.0.0)"]
 
 [[package]]
 name = "typing-extensions"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ databooks = "databooks.cli:app"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-typer = "^0.4.0"
+typer = ">=0.4.0,<1.0.0"
 rich = "^12.6.0"
 pydantic = "^1.8.2"
 GitPython = "^3.1.24"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -136,10 +136,7 @@ def test_meta__script(tmp_path: Path) -> None:
 
     result = runner.invoke(app, ["meta", str(py_path)])
     assert result.exit_code == 2
-    assert (
-        "Expected either notebook files, a directory or glob expression."
-        in result.output
-    )
+    assert "Expected either notebook files, a directory or glob " in result.output
 
 
 def test_meta__no_confirm(tmp_path: Path) -> None:
@@ -151,9 +148,9 @@ def test_meta__no_confirm(tmp_path: Path) -> None:
 
     assert result.exit_code == 1
     assert JupyterNotebook.parse_file(nb_path) == TestJupyterNotebook().jupyter_notebook
-    assert result.output == (
+    assert result.output.startswith(
         "1 files will be overwritten (no prefix nor suffix was passed)."
-        " Continue? [y/n]: \nAborted!\n"
+        " Continue? [y/n]: \nAborted"
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,7 +150,7 @@ def test_meta__no_confirm(tmp_path: Path) -> None:
     assert JupyterNotebook.parse_file(nb_path) == TestJupyterNotebook().jupyter_notebook
     assert result.output.startswith(
         "1 files will be overwritten (no prefix nor suffix was passed)."
-        " Continue? [y/n]: \nAborted"
+        " Continue? [y/n]:"
     )
 
 


### PR DESCRIPTION
Relax typer constraint to `^0.4.0` to `>=0.4.0,<1.0.0`.
Otherwise we'd only allow Typer up to `<0.5.0`, as Poetry looks to keep the leftmost non-zero number unchanged.

https://python-poetry.org/docs/dependency-specification/#caret-requirements

Closes https://github.com/datarootsio/databooks/issues/46