### PR TITLE
Repo found from paths

### DIFF
--- a/databooks/common.py
+++ b/databooks/common.py
@@ -10,7 +10,7 @@ logger = get_logger(__file__)
 
 def expand_paths(
     paths: List[Path], *, ignore: Sequence[str] = ("!*",), rglob: str = "*.ipynb"
-) -> List[Path]:
+) -> Optional[List[Path]]:
     """
     Get paths of existing file from list of directory or file paths.
 
@@ -20,13 +20,16 @@ def expand_paths(
      existing file paths (i.e.: to retrieve only notebooks)
     :return: List of existing file paths
     """
+    if not paths:
+        return None
     filepaths = set(
         chain.from_iterable(
             list(path.resolve().rglob(rglob)) if path.is_dir() else [path]
             for path in paths
         )
     )
-    ignored = set(chain.from_iterable(Path.cwd().rglob(i) for i in ignore))
+    common_path = find_common_parent(paths=paths)
+    ignored = set(chain.from_iterable(common_path.rglob(i) for i in ignore))
     ignored = {p.resolve() for p in ignored}
     logger.debug(
         f"{len(ignored)} files will be ignored from {len(filepaths)} file paths."

--- a/databooks/config.py
+++ b/databooks/config.py
@@ -16,7 +16,8 @@ logger = get_logger(__file__)
 def get_config(target_paths: List[Path], config_filename: str) -> Optional[Path]:
     """Find configuration file from CLI target paths."""
     common_path = find_common_parent(paths=target_paths)
-    repo_dir = get_repo().working_dir
+    repo = get_repo(common_path)
+    repo_dir = getattr(repo, "working_dir", None)
 
     return find_obj(
         obj_name=config_filename,

--- a/databooks/conflicts.py
+++ b/databooks/conflicts.py
@@ -31,6 +31,8 @@ def path2conflicts(
         )
     common_parent = find_common_parent(nb_paths)
     repo = get_repo(common_parent) if repo is None else repo
+    if repo is None:
+        raise ValueError("No repo found - cannot compute conflict blobs.")
     return [
         file
         for file in get_conflict_blobs(repo=repo)

--- a/databooks/git_utils.py
+++ b/databooks/git_utils.py
@@ -109,14 +109,18 @@ def diff2contents(
         return blob2str(blob)
 
 
-def get_repo(path: Path = Path.cwd()) -> Repo:
+def get_repo(path: Path) -> Optional[Repo]:
     """Find git repo in current or parent directories."""
     repo_dir = find_obj(
         obj_name=".git", start=Path(path.anchor), finish=path, is_dir=True
     )
-    repo = Repo(path=repo_dir)
-    logger.debug(f"Repo found at: {repo.working_dir}")
-    return repo
+    if repo_dir is not None:
+        repo = Repo(path=repo_dir)
+        logger.debug(f"Repo found at: {repo.working_dir}.")
+        return repo
+    else:
+        logger.debug(f"No repo found at {path}.")
+        return None
 
 
 def get_conflict_blobs(repo: Repo) -> List[ConflictFile]:
@@ -164,7 +168,7 @@ def get_nb_diffs(
 
     common_path = find_common_parent(paths or [Path.cwd()])
     repo = get_repo(path=common_path) if repo is None else repo
-    if repo.working_dir is None:
+    if repo is None or repo.working_dir is None:
         raise ValueError("No repo found - cannot compute diffs.")
 
     ref_base = repo.index if ref_base is None else repo.tree(ref_base)

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -64,6 +64,11 @@ def test_get_repo() -> None:
     assert Path(repo.working_dir).stem == "databooks"
 
 
+def test_get_repo_missing(tmp_path: Path) -> None:
+    """Return `None` if there is no repo."""
+    assert get_repo(tmp_path) is None
+
+
 def test_get_conflict_blobs(tmp_path: Path) -> None:
     """Return `databooks.git_utils.ConflctFile` from git merge conflict."""
     filepath = Path("hello.txt")


### PR DESCRIPTION
- We should not need the git repo for `meta` and `assert` commands
- Config files/repos should always be located from the filepaths, not current working directory
  - Only exception is when we run `databooks diff` with no paths - in that case we use the current dir to find the repo
  - Not the case for `databooks fix` requires paths

Closes https://github.com/datarootsio/databooks/issues/48