### PR TITLE
Fix the location of LICENSE file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,6 @@ readme = "README.md"
 homepage = "https://datarootsio.github.io/databooks/"
 repository = "https://github.com/datarootsio/databooks/"
 keywords = ["jupyter-notebooks", "cli"]
-include = [
-    "LICENSE",
-]
 
 [tool.poetry.scripts]
 databooks = "databooks.cli:app"


### PR DESCRIPTION
LICENSE is included automatically by poetry and it's installed
into .dist-info directory. This manual include caused the file to
be installed also into lib/python3.11/site-packages next
to the main databooks package.